### PR TITLE
Fix clicking on notifications

### DIFF
--- a/electron/src/electron-main.js
+++ b/electron/src/electron-main.js
@@ -202,3 +202,9 @@ electron.app.on('activate', () => {
 electron.app.on('before-quit', () => {
     appQuitting = true;
 });
+
+// Set the App User Model ID to match what the squirrel
+// installer uses for the shortcut icon.
+// This makes notifications work on windows 8.1 (and is
+// a noop on other platforms).
+electron.app.setAppUserModelId('com.squirrel.riot-web.Riot');

--- a/src/vector/platform/ElectronPlatform.js
+++ b/src/vector/platform/ElectronPlatform.js
@@ -79,7 +79,7 @@ export default class ElectronPlatform extends VectorBasePlatform {
         return true;
     }
 
-    displayNotification(title: string, msg: string, avatarUrl: string): Notification {
+    displayNotification(title: string, msg: string, avatarUrl: string, room: Object): Notification {
         // Notifications in Electron use the HTML5 notification API
         const notification = new global.Notification(
             title,
@@ -97,6 +97,7 @@ export default class ElectronPlatform extends VectorBasePlatform {
                 room_id: room.roomId
             });
             global.focus();
+            electron.remote.getCurrentWindow().restore();
         };
 
         return notification;

--- a/src/vector/platform/WebPlatform.js
+++ b/src/vector/platform/WebPlatform.js
@@ -103,7 +103,7 @@ export default class WebPlatform extends VectorBasePlatform {
         return defer.promise;
     }
 
-    displayNotification(title: string, msg: string, avatarUrl: string) {
+    displayNotification(title: string, msg: string, avatarUrl: string, room: Object) {
         const notification = new global.Notification(
             title,
             {
@@ -120,6 +120,7 @@ export default class WebPlatform extends VectorBasePlatform {
                 room_id: room.roomId
             });
             global.focus();
+            notification.close();
         };
 
         // Chrome only dismisses notifications after 20s, which


### PR DESCRIPTION
* Dismiss the notification when it's clicked
 * Accept the room object: we need it to view_room
 * Desktop app: Un-minimise when notification clicked
 * Desktop App: Set App User Model ID so notifications work on
   Windows 8!

Requires https://github.com/matrix-org/matrix-react-sdk/pull/582