### PR TITLE
Add missing brackets to call to toUpperCase

### DIFF
--- a/src/vector/platform/ElectronPlatform.js
+++ b/src/vector/platform/ElectronPlatform.js
@@ -52,7 +52,7 @@ function platformFriendlyName() {
             // Sorry, Linux users: you get lumped into here,
             // but only because Linux's capitalisation is
             // normal. We do care about you.
-            return window.process.platform[0].toUpperCase + window.process.platform.slice(1);
+            return window.process.platform[0].toUpperCase() + window.process.platform.slice(1);
     }
 }
 


### PR DESCRIPTION
Currently, Linux builds get identified as "function toUpperCase() { [native code] }inux", which I don't think is the correct capitalization of "linux"