### PR TITLE
Add edit-button to context menu behind toggle

### DIFF
--- a/src/components/views/context_menus/MessageContextMenu.js
+++ b/src/components/views/context_menus/MessageContextMenu.js
@@ -37,6 +37,9 @@ module.exports = React.createClass({
 
         /* callback called when the menu is dismissed */
         onFinished: React.PropTypes.func,
+
+        /* Edit Mesage functionality is enabled */
+        editEnabled: React.PropTypes.bool,
     },
 
     onResendClick: function() {
@@ -102,6 +105,15 @@ module.exports = React.createClass({
         });
     },
 
+    onEditClick: function onEditClick() {
+        console.log(this.props.mxEvent);
+        dis.dispatch({
+            action: 'edit',
+            mxEvent: this.props.mxEvent
+        });
+    },
+
+
     render: function() {
         var eventStatus = this.props.mxEvent.status;
         var resendButton;
@@ -112,6 +124,7 @@ module.exports = React.createClass({
         var permalinkButton;
         var unhidePreviewButton;
         var externalURLButton;
+        var editButton;
 
         if (eventStatus === 'not_sent') {
             resendButton = (
@@ -133,6 +146,15 @@ module.exports = React.createClass({
             cancelButton = (
                 <div className="mx_MessageContextMenu_field" onClick={this.onCancelSendClick}>
                     Cancel Sending
+                </div>
+            );
+        }
+
+        if (!eventStatus && this.props.editEnabled) {
+            // sent
+            editButton = (
+                <div className="mx_MessageContextMenu_field" onClick={this.onEditClick}>
+                    Edit
                 </div>
             );
         }
@@ -190,6 +212,7 @@ module.exports = React.createClass({
             <div>
                 {resendButton}
                 {redactButton}
+                {editButton}
                 {cancelButton}
                 {viewSourceButton}
                 {viewClearSourceButton}


### PR DESCRIPTION
PR to add an editButton (hidden by default) to the riot-web client `TextualBody` should receive the `edit` message and render a `MessageEditorInput` on action dispatch. 

Not sure where config toggles is/are riot-web so I should update the `editEnabled` property to point to that, potentially it should be received from the server? That way it would be possible to run an experimental synapse with `edit` functionality and have a client with functional edit-mode without running a fork of vector-web. 