### PR TITLE
Make the 'loading' tests work in isolation

### DIFF
--- a/test/app-tests/loading.js
+++ b/test/app-tests/loading.js
@@ -16,6 +16,8 @@ limitations under the License.
 
 /* loading.js: test the myriad paths we have for loading the application */
 
+import 'skin-sdk';
+
 import React from 'react';
 import ReactDOM from 'react-dom';
 import ReactTestUtils from 'react-addons-test-utils';


### PR DESCRIPTION
The 'loading' tests only worked when run with the other tests and
failed if you just ran the file by itself, because the skin was
loading in the 'joining' tests, but not here.