### PR TITLE
Fix broken tests

### DIFF
--- a/test/app-tests/loading.js
+++ b/test/app-tests/loading.js
@@ -155,6 +155,9 @@ describe('loading:', function () {
 
                 return httpBackend.flush();
             }).then(() => {
+                // Wait for another trip around the event loop for the UI to update
+                return q.delay(1);
+            }).then(() => {
                 // we expect a single <Login> component
                 ReactTestUtils.findRenderedComponentWithType(
                     matrixChat, sdk.getComponent('structures.login.Login'));
@@ -178,6 +181,9 @@ describe('loading:', function () {
 
                 return httpBackend.flush();
             }).then(() => {
+                // Wait for another trip around the event loop for the UI to update
+                return q.delay(1);
+            }).then(() => {
                 // we expect a single <Login> component
                 let login = ReactTestUtils.findRenderedComponentWithType(
                     matrixChat, sdk.getComponent('structures.login.Login'));
@@ -192,6 +198,9 @@ describe('loading:', function () {
                 login.onPasswordLogin("user", "pass")
                 return httpBackend.flush();
             }).then(() => {
+                // Wait for another trip around the event loop for the UI to update
+                return q.delay(1);
+            }).then(() => {
                 // we expect a spinner
                 ReactTestUtils.findRenderedComponentWithType(
                     matrixChat, sdk.getComponent('elements.Spinner'));
@@ -200,6 +209,9 @@ describe('loading:', function () {
                 httpBackend.when('POST', '/filter').respond(200, { filter_id: 'fid' });
                 httpBackend.when('GET', '/sync').respond(200, {});
                 return httpBackend.flush();
+            }).then(() => {
+                // Wait for another trip around the event loop for the UI to update
+                return q.delay(1);
             }).then(() => {
                 // once the sync completes, we should have a room view
                 httpBackend.verifyNoOutstandingExpectation();
@@ -288,6 +300,9 @@ describe('loading:', function () {
 
                 return httpBackend.flush();
             }).then(() => {
+                // Wait for another trip around the event loop for the UI to update
+                return q.delay(1);
+            }).then(() => {
                 // now we should have a spinner with a logout link
                 assertAtSyncingSpinner(matrixChat);
 
@@ -322,6 +337,9 @@ describe('loading:', function () {
                 });
 
                 return httpBackend.flush();
+            }).then(() => {
+                // Wait for another trip around the event loop for the UI to update
+                return q.delay(1);
             }).then(() => {
                 // now we should have a spinner with a logout link
                 assertAtSyncingSpinner(matrixChat);
@@ -359,11 +377,17 @@ describe('loading:', function () {
 
                 return httpBackend.flush();
             }).then(() => {
+                // Wait for another trip around the event loop for the UI to update
+                return q.delay(1);
+            }).then(() => {
                 // now we should have a spinner with a logout link
                 assertAtSyncingSpinner(matrixChat);
 
                 httpBackend.when('GET', '/sync').respond(200, {});
                 return httpBackend.flush();
+            }).then(() => {
+                // Wait for another trip around the event loop for the UI to update
+                return q.delay(1);
             }).then(() => {
                 // once the sync completes, we should have a room view
                 httpBackend.verifyNoOutstandingExpectation();


### PR DESCRIPTION
Promises are now not being resolved within the same tick, so give
another tick for the UI to update after all the HTTP calls have
flushed through. This is fairly terrible, but I can't immediately
see a better way of doing this.