### PR TITLE
Remove the client side filtering from the room dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,33 +81,9 @@ You can configure the app by copying `config.sample.json` to
    and https://vector.im.  In future identity servers will be decentralised.
 1. `integrations_ui_url`: URL to the web interface for the integrations server.
 1. `integrations_rest_url`: URL to the REST interface for the integrations server.
-1. `roomDirectory`: config for the public room directory. This section encodes behaviour
-   on the room directory screen for filtering the list by server / network type and joining
-   third party networks. This config section will disappear once APIs are available to
-   get this information for home servers. This section is optional.
+1. `roomDirectory`: config for the public room directory. This section is optional.
 1. `roomDirectory.servers`: List of other Home Servers' directories to include in the drop
    down list. Optional.
-1. `roomDirectory.serverConfig`: Config for each server in `roomDirectory.servers`. Optional.
-1. `roomDirectory.serverConfig.<server_name>.networks`: List of networks (named
-   in `roomDirectory.networks`) to include for this server. Optional. If set, this will
-   override any networks sent by the Home Server (eg. if ASes are configured).
-1. `roomDirectory.networks`: config for each network type. Optional.
-1. `roomDirectory.<network_type>.name`: Human-readable name for the network. Required.
-1. `roomDirectory.<network_type>.protocol`: Protocol as given by the server in
-   `/_matrix/client/unstable/thirdparty/protocols` response. Required to be able to join
-   this type of third party network.
-1. `roomDirectory.<network_type>.domain`: Domain as given by the server in
-   `/_matrix/client/unstable/thirdparty/protocols` response, if present. Required to be
-   able to join this type of third party network, if present in `thirdparty/protocols`.
-1. `roomDirectory.<network_type>.portalRoomPattern`: Regular expression matching aliases
-   for portal rooms to locations on this network. Required.
-1. `roomDirectory.<network_type>.icon`: URL to an icon to be displayed for this network. Required.
-1. `roomDirectory.<network_type>.example`: Textual example of a location on this network,
-   eg. '#channel' for an IRC network. Optional.
-1. `roomDirectory.<network_type>.nativePattern`: Regular expression that matches a
-   valid location on this network. This is used as a hint to the user to indicate
-   when a valid location has been entered so it's not necessary for this to be
-   exactly correct. Optional.
 1. `update_base_url` (electron app only): HTTPS URL to a web server to download
    updates from. This should be the path to the directory containing `macos`
    and `win32` (for update packages, not installer packages).

--- a/config.sample.json
+++ b/config.sample.json
@@ -8,64 +8,6 @@
     "roomDirectory": {
         "servers": [
             "matrix.org"
-        ],
-        "serverConfig": {
-            "matrix.org": {
-                "networks": [
-                    "_matrix",
-                    "gitter",
-                    "irc:freenode",
-                    "irc:mozilla",
-                    "irc:snoonet",
-                    "irc:oftc"
-                ]
-            }
-        },
-        "networks": {
-            "gitter": {
-                "protocol": "gitter",
-                "portalRoomPattern": "#gitter_.*:matrix.org",
-                "name": "Gitter",
-                "icon": "//gitter.im/favicon.ico",
-                "example": "org/community",
-                "nativePattern": "[^\\s]+/[^\\s]+$"
-            },
-            "irc:freenode": {
-                "protocol": "irc",
-                "domain": "chat.freenode.net",
-                "portalRoomPattern": "#freenode_.*:matrix.org",
-                "name": "Freenode",
-                "icon": "//matrix.org/_matrix/media/v1/download/matrix.org/DHLHpDDgWNNejFmrewvwEAHX",
-                "example": "#channel",
-                "nativePattern": "^#[^\\s]+$"
-            },
-            "irc:mozilla": {
-                "protocol": "irc",
-                "domain": "irc.mozilla.org",
-                "portalRoomPattern": "#mozilla_.*:matrix.org",
-                "name": "Mozilla",
-                "icon": "//matrix.org/_matrix/media/v1/download/matrix.org/DHLHpDDgWNNejFmrewvwEAHX",
-                "example": "#channel",
-                "nativePattern": "^#[^\\s]+$"
-            },
-            "irc:snoonet": {
-                "protocol": "irc",
-                "domain": "ipv6-irc.snoonet.org",
-                "portalRoomPattern": "#_snoonet_.*:matrix.org",
-                "name": "Snoonet",
-                "icon": "//matrix.org/_matrix/media/v1/download/matrix.org/DHLHpDDgWNNejFmrewvwEAHX",
-                "example": "#channel",
-                "nativePattern": "^#[^\\s]+$"
-            },
-            "irc:oftc": {
-                "protocol": "irc",
-                "domain": "irc.oftc.net",
-                "portalRoomPattern": "#_oftc_.*:matrix.org",
-                "name": "OFTC",
-                "icon": "//matrix.org/_matrix/media/v1/download/matrix.org/DHLHpDDgWNNejFmrewvwEAHX",
-                "example": "#channel",
-                "nativePattern": "^#[^\\s]+$"
-            }
-        }
+        ]
     }
 }

--- a/src/components/structures/RoomDirectory.js
+++ b/src/components/structures/RoomDirectory.js
@@ -282,7 +282,7 @@ module.exports = React.createClass({
     },
 
     onJoinClick: function(alias) {
-        // If we don't have a prticular instance id selected, just show that rooms alias
+        // If we don't have a particular instance id selected, just show that rooms alias
         if (!this.state.instanceId) {
             // If the user specified an alias without a domain, add on whichever server is selected
             // in the dropdown

--- a/src/components/views/directory/NetworkDropdown.js
+++ b/src/components/views/directory/NetworkDropdown.js
@@ -180,7 +180,7 @@ export default class NetworkDropdown extends React.Component {
             icon = <img src="img/network-matrix.svg" />;
             span_class = 'mx_NetworkDropdown_menu_network';
         } else {
-            key = server + '_inst_'+instance.instance_id;
+            key = server + '_inst_' + instance.instance_id;
             icon = <img src={instance.icon || DEFAULT_ICON_URL} />;
             name = instance.desc;
             span_class = 'mx_NetworkDropdown_menu_network';
@@ -227,6 +227,7 @@ export default class NetworkDropdown extends React.Component {
 NetworkDropdown.propTypes = {
     onOptionChange: React.PropTypes.func.isRequired,
     protocols: React.PropTypes.object,
+    // The room directory config. May have a 'servers' key that is a list of server names to include in the dropdown
     config: React.PropTypes.object,
 };
 

--- a/src/utils/DirectoryUtils.js
+++ b/src/utils/DirectoryUtils.js
@@ -1,0 +1,23 @@
+// Find a protocol 'instance' with a given instance_id
+// in the supplied protocols dict
+export function instanceForInstanceId(protocols, instance_id) {
+    if (!instance_id) return null;
+    for (const proto of Object.keys(protocols)) {
+        if (!protocols[proto].instances) continue;
+        for (const instance of protocols[proto].instances) {
+            if (instance.instance_id == instance_id) return instance;
+        }
+    }
+}
+
+// given an instance_id, return the name of the protocol for
+// that instance ID in the supplied protocols dict
+export function protocolNameForInstanceId(protocols, instance_id) {
+    if (!instance_id) return null;
+    for (const proto of Object.keys(protocols)) {
+        if (!protocols[proto].instances) continue;
+        for (const instance of protocols[proto].instances) {
+            if (instance.instance_id == instance_id) return proto;
+        }
+    }
+}

--- a/src/utils/DirectoryUtils.js
+++ b/src/utils/DirectoryUtils.js
@@ -3,7 +3,7 @@
 export function instanceForInstanceId(protocols, instance_id) {
     if (!instance_id) return null;
     for (const proto of Object.keys(protocols)) {
-        if (!protocols[proto].instances) continue;
+        if (!protocols[proto].instances && protocols[proto].instances instanceof Array) continue;
         for (const instance of protocols[proto].instances) {
             if (instance.instance_id == instance_id) return instance;
         }
@@ -15,7 +15,7 @@ export function instanceForInstanceId(protocols, instance_id) {
 export function protocolNameForInstanceId(protocols, instance_id) {
     if (!instance_id) return null;
     for (const proto of Object.keys(protocols)) {
-        if (!protocols[proto].instances) continue;
+        if (!protocols[proto].instances && protocols[proto].instances instanceof Array) continue;
         for (const instance of protocols[proto].instances) {
             if (instance.instance_id == instance_id) return proto;
         }

--- a/test/app-tests/joining.js
+++ b/test/app-tests/joining.js
@@ -77,6 +77,7 @@ describe('joining a room', function () {
             httpBackend.when('POST', '/filter').respond(200, { filter_id: 'fid' });
             httpBackend.when('GET', '/sync').respond(200, {});
             httpBackend.when('POST', '/publicRooms').respond(200, {chunk: []});
+            httpBackend.when('GET', '/thirdparty/protocols').respond(200, {});
             httpBackend.when('GET', '/directory/room/'+encodeURIComponent(ROOM_ALIAS)).respond(200, { room_id: ROOM_ID });
 
             // start with a logged-in client
@@ -131,6 +132,12 @@ describe('joining a room', function () {
                     .respond(200, {displayname: 'boris'});
                 httpBackend.when('POST', '/join/'+encodeURIComponent(ROOM_ALIAS))
                     .respond(200, {room_id: ROOM_ID});
+                return httpBackend.flush();
+            }).then(() => {
+                // wait for the join request to be made
+                return q.delay(1);
+            }).then(() => {
+                // flush it through
                 return httpBackend.flush();
             }).then(() => {
                 httpBackend.verifyNoOutstandingExpectation();


### PR DESCRIPTION
This removes the ability for the client to filter remote room
directories by network, since the /thirdparty/protocols API does
not yet work for remote servers. They would only get the main list
now though anyway, so there is no point in us continuing to support
it.