### PR TITLE
README.md: fix GFMD for nativefier

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,10 +140,11 @@ Many thanks to @aviraldg for the initial work on the electron integration.
 Other options for running as a desktop app:
  * https://github.com/krisak/vector-electron-desktop
  * @asdf:matrix.org points out that you can use nativefier and it just works(tm)
-   ```
-   sudo npm install nativefier -g
-   nativefier https://riot.im/app/
-   ```
+
+```
+sudo npm install nativefier -g
+nativefier https://riot.im/app/
+```
 
 Development
 ===========


### PR DESCRIPTION
GitHub Flavoured MarkDown parsed this as
`sudo npm install nativefier -g nativefier https://riot.im/app/` which
is incorrect.