### PR TITLE
Redeploy script: put each build in a separate directory

### DIFF
--- a/scripts/redeploy.py
+++ b/scripts/redeploy.py
@@ -116,7 +116,11 @@ def on_receive_jenkins_poke():
     try:
         # we extract into a directory based on the build number. This avoids the
         # problem of multiple builds building the same git version and thus having
-        # the same tarball name.
+        # the same tarball name. That would lead to two potential problems:
+        #   (a) sometimes jenkins serves corrupted artifacts; we would replace
+        #       a good deploy with a bad one
+        #   (b) we'll be overwriting the live deployment, which means people might
+        #       see half-written files.
         build_dir = os.path.join(arg_extract_path, "%s-#%s" % (job_name, build_num))
         if os.path.exists(build_dir):
             abort(400, "Not deploying. We have previously deployed this build.")

--- a/scripts/redeploy.py
+++ b/scripts/redeploy.py
@@ -120,6 +120,7 @@ def on_receive_jenkins_poke():
         build_dir = os.path.join(arg_extract_path, "%s-#%s" % (job_name, build_num))
         if os.path.exists(build_dir):
             abort(400, "Not deploying. We have previously deployed this build.")
+            return
         os.mkdir(build_dir)
 
         untar_to(filename, build_dir)


### PR DESCRIPTION
Hopefully this will fix the problem whereby we can overwrite the live
deployment.