### PR TITLE
make electron send email validation URLs with a nextlink of riot.im

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ The only platform that can build packages for all three platforms is macOS:
 ```
 brew install wine --without-x11
 brew install mono
+brew install gnu-tar
 npm install
 npm run build:electron
 ```

--- a/electron/src/squirrelhooks.js
+++ b/electron/src/squirrelhooks.js
@@ -3,7 +3,7 @@ const spawn = require('child_process').spawn;
 const app = require('electron').app;
 
 function run_update_exe(args, done) {
-    const updateExe = path.resolve(path.dirname(process.execPath), '..', 'Update.exe');
+    const updateExe = path.resolve(path.dirname(process.execPath), 'Update.exe');
     spawn(updateExe, args, {
       detached: true
     }).on('close', done);

--- a/src/vector/index.js
+++ b/src/vector/index.js
@@ -136,11 +136,20 @@ var onNewScreen = function(screen) {
 // click back to the client having registered.
 // It's up to us to recognise if we're loaded with
 // this URL and tell MatrixClient to resume registration.
+//
+// If we're in electron, we should never pass through a file:// URL otherwise
+// the identity server will try to 302 the browser to it, which breaks horribly.
+// so in that instance, hardcode to use riot.im/app for now instead.
 var makeRegistrationUrl = function() {
-    return window.location.protocol + '//' +
-           window.location.host +
-           window.location.pathname +
-           '#/register';
+    if (window.location.protocol === "file:") {
+        return 'https://riot.im/app/#/register';
+    }
+    else {
+        return window.location.protocol + '//' +
+               window.location.host +
+               window.location.pathname +
+               '#/register';
+    }
 }
 
 window.addEventListener('hashchange', onHashChange);


### PR DESCRIPTION
rather than file:///, which crashes browsers in horrible ways c.f. https://twitter.com/agumonkey/status/812060535567040512.  This was already worked around on sydent.