### PR TITLE
add Debian Stretch install steps to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,14 @@ Note that Chrome does not allow microphone or webcam access for sites served
 over http (except localhost), so for working VoIP you will need to serve Riot
 over https.
 
+### Installation Steps for Debian Stretch
+1. Add the repository to your sources.list using either of the following two options:
+  - Directly to sources.list: `echo "deb https://riot.im/packages/debian/ stretch main" | sudo tee -a /etc/apt/sources.list`
+  - As a separate entry in sources.list.d: `echo "deb https://riot.im/packages/debian/ stretch main" | sudo tee /etc/apt/sources.list.d/riot.list`
+2. Add the gpg signing key for the riot repository: `curl -s https://riot.im/packages/debian/repo-key.asc | sudo apt-key add -`
+3. Update your package lists: `sudo apt-get update`
+4. Install Riot: `sudo apt-get install riot-web`
+
 Important Security Note
 =======================
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "riot-web",
   "productName": "Riot",
   "main": "electron/src/electron-main.js",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "A feature-rich client for Matrix.org",
   "author": "Vector Creations Ltd.",
   "repository": {


### PR DESCRIPTION
Not sure if this is the right place to put it, but I think it'd be useful to spell out the installation steps for Debian to make it easier to install. Even though Debian users are typically aware of these installation steps, it makes it easier if there are easy copy/paste commands to get the app installed.