### PR TITLE
Add ISSUE_TEMPLATE

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,31 @@
+<!-- This is a bug report template. By following the instructions below and filling out the sections with your information, you will help the developers to get all the necessary data to fix your issue.
+You can also preview your report before submitting it. You may remove sections that aren't relevant to your particular case.
+
+Let's begin with a checklist: replace the empty checkbox [ ] below with a checked one [x] if you already searched for duplicate bugs -->
+
+I have:
+- [ ] searched open and closed issues for duplicates
+
+----------------------------------------
+
+### Version info
+<!-- please replace the examples with your info -->
+**Riot (vector-web) Version:** 0.0.0
+**Operating System:**
+
+### Bug description
+Describe here the issue that you are experiencing.
+
+### Steps to reproduce
+- using hyphens as bullet points
+- list the steps
+- that reproduce the bug
+
+**Actual result:** Describe here what happens after you run the steps above (i.e. the buggy behaviour)
+**Expected result:** Describe here what should happen after you run the steps above (i.e. what would be the correct behaviour)
+
+### Screenshots
+<!-- you can drag and drop images below -->
+
+### debug log
+<!-- posting a debug log helps the developers to fix your issue -->


### PR DESCRIPTION
This PR adds a default template for new issues created on GitHub such that contributors will fill out more details that help developers define and create features that are aligned with user-expected results.