### PR TITLE
add colon to timestamp

### DIFF
--- a/src/components/views/messages/MessageTimestamp.js
+++ b/src/components/views/messages/MessageTimestamp.js
@@ -26,7 +26,7 @@ module.exports = React.createClass({
         var date = new Date(this.props.ts);
         return (
             <span className="mx_MessageTimestamp">
-                { DateUtils.formatTime(date) }
+                { DateUtils.formatTime(date)+':' }
             </span>
         );
     },


### PR DESCRIPTION
This solves part of the problem that the timestamp is  gluing at the message, when copied in your clipboard.

Example:

    23:02test message

see https://github.com/vector-im/riot-web/issues/893