### PR TITLE
Hide Options button from copy to clipboard

### DIFF
--- a/src/skins/vector/css/matrix-react-sdk/views/rooms/EventTile.css
+++ b/src/skins/vector/css/matrix-react-sdk/views/rooms/EventTile.css
@@ -172,6 +172,10 @@ limitations under the License.
     cursor: pointer;
     top: 6px;
     right: 6px;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
 }
 
 .mx_EventTile:hover .mx_EventTile_editButton,


### PR DESCRIPTION
This solves that the word "Options" is copied to your clipboard.

part of the problem: https://github.com/vector-im/riot-web/issues/893