### PR TITLE
Add basic close-to-tray support for windows and linux

### DIFF
--- a/electron/src/electron-main.js
+++ b/electron/src/electron-main.js
@@ -26,6 +26,8 @@ if (check_squirrel_hooks()) return;
 const electron = require('electron');
 const url = require('url');
 
+const tray = require('./tray');
+
 const VectorMenu = require('./vectormenu');
 
 let vectorConfig = {};
@@ -170,6 +172,12 @@ electron.app.on('ready', () => {
     mainWindow.loadURL(`file://${__dirname}/../../webapp/index.html`);
     electron.Menu.setApplicationMenu(VectorMenu);
 
+    // Create trayIcon icon
+    tray.create(mainWindow, {
+        icon_path: icon_path,
+        brand: vectorConfig.brand || 'Riot'
+    });
+
     mainWindow.once('ready-to-show', () => {
         mainWindow.show();
     });
@@ -177,7 +185,7 @@ electron.app.on('ready', () => {
         mainWindow = null;
     });
     mainWindow.on('close', (e) => {
-        if (process.platform == 'darwin' && !appQuitting) {
+        if (!appQuitting && (tray.hasTray() || process.platform == 'darwin')) {
             // On Mac, closing the window just hides it
             // (this is generally how single-window Mac apps
             // behave, eg. Mail.app)

--- a/electron/src/electron-main.js
+++ b/electron/src/electron-main.js
@@ -152,6 +152,19 @@ electron.ipcMain.on('install_update', installUpdate);
 
 electron.app.commandLine.appendSwitch('--enable-usermedia-screen-capturing');
 
+const shouldQuit = electron.app.makeSingleInstance((commandLine, workingDirectory) => {
+    // Someone tried to run a second instance, we should focus our window.
+    if (mainWindow) {
+        if (!mainWindow.isVisible()) mainWindow.show();
+        if (mainWindow.isMinimized()) mainWindow.restore();
+        mainWindow.focus();
+    }
+});
+
+if (shouldQuit) {
+    electron.app.quit()
+}
+
 electron.app.on('ready', () => {
     if (vectorConfig.update_base_url) {
         console.log("Starting auto update with base URL: " + vectorConfig.update_base_url);

--- a/electron/src/tray.js
+++ b/electron/src/tray.js
@@ -1,0 +1,49 @@
+const path = require('path');
+const electron = require('electron');
+
+const app = electron.app;
+const Tray = electron.Tray;
+const MenuItem = electron.MenuItem;
+
+let trayIcon = null;
+
+exports.hasTray = function hasTray() {
+    return (trayIcon !== null);
+}
+
+exports.create = function (win, config) {
+    // no trays on darwin
+    if (process.platform === 'darwin' || trayIcon) {
+        return;
+    }
+
+    const toggleWin = function () {
+        if (win.isVisible()) {
+            win.hide();
+        } else {
+            win.show();
+            win.focus();
+        }
+    };
+
+    const contextMenu = electron.Menu.buildFromTemplate([
+        {
+            label: 'Show/Hide ' + config.brand,
+            click: toggleWin
+        },
+        {
+            type: 'separator'
+        },
+        {
+            label: 'Quit',
+            click: function () {
+                app.quit();
+            }
+        }
+    ]);
+
+    trayIcon = new Tray(config.icon_path);
+    trayIcon.setToolTip(config.brand);
+    trayIcon.setContextMenu(contextMenu);
+    trayIcon.on('click', toggleWin);
+};

--- a/src/vector/platform/ElectronPlatform.js
+++ b/src/vector/platform/ElectronPlatform.js
@@ -131,4 +131,10 @@ export default class ElectronPlatform extends VectorBasePlatform {
     screenCaptureErrorString() {
         return null;
     }
+
+    requestNotificationPermission() : Promise {
+        const defer = q.defer();
+        defer.resolve('granted');
+        return defer.promise;
+    }
 }

--- a/src/vector/platform/ElectronPlatform.js
+++ b/src/vector/platform/ElectronPlatform.js
@@ -97,7 +97,10 @@ export default class ElectronPlatform extends VectorBasePlatform {
                 room_id: room.roomId
             });
             global.focus();
-            electron.remote.getCurrentWindow().restore();
+            let currentWin = electron.remote.getCurrentWindow();
+            currentWin.show();
+            currentWin.restore();
+            currentWin.focus();
         };
 
         return notification;


### PR DESCRIPTION
Creates a tray icon on windows and linux (or: not mac) and keeps the application running in the background when the user closes the window (close-to-tray). There is no configuration support yet.

See issue #2799

Signed-off-by: Karl Glatz <karl@glatz.biz>