### PR TITLE
Put parent build hash in webpack output filenames

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -40,7 +40,8 @@ module.exports = {
     },
     output: {
         path: path.join(__dirname, "webapp"),
-        filename: "[name].[chunkhash].js",
+        filename: "[hash]/[name].js",
+        chunkFilename: "[hash]/[name].js",
         devtoolModuleFilenameTemplate: function(info) {
             // Reading input source maps gives only relative paths here for
             // everything. Until I figure out how to fix this, this is a
@@ -79,7 +80,7 @@ module.exports = {
         }),
 
         new ExtractTextPlugin(
-            "[name].[contenthash].css",
+            "[hash]/[name].css",
             {
                 allChunks: true
             }


### PR DESCRIPTION
In order to better support a world where old build artifacts are available
(which is necessary to support bundle.js splitting), collect all the webpack
artifacts for the build into a single directory. Then we'll be able to clear
out old builds after a few weeks, knowing they won't be in use any more.