### PR TITLE
Auto-hide the electron menu bar

### DIFF
--- a/electron/src/electron-main.js
+++ b/electron/src/electron-main.js
@@ -175,6 +175,7 @@ electron.app.on('ready', () => {
         icon: icon_path,
         width: 1024, height: 768,
         show: false,
+        autoHideMenuBar: true,
     });
     mainWindow.loadURL(`file://${__dirname}/../../webapp/index.html`);
     electron.Menu.setApplicationMenu(VectorMenu);


### PR DESCRIPTION
From https://github.com/vector-im/riot-web/issues/2962

This allows all the shortcuts to still work, and the menu bar can
be un-hidden with the alt key.