### PR TITLE
Fixes to electron desktop notifs

### DIFF
--- a/src/vector/platform/ElectronPlatform.js
+++ b/src/vector/platform/ElectronPlatform.js
@@ -97,7 +97,10 @@ export default class ElectronPlatform extends VectorBasePlatform {
                 room_id: room.roomId
             });
             global.focus();
-            electron.remote.getCurrentWindow().restore();
+            const currentWin = electron.remote.getCurrentWindow();
+            currentWin.show();
+            currentWin.restore();
+            currentWin.focus();
         };
 
         return notification;
@@ -130,5 +133,9 @@ export default class ElectronPlatform extends VectorBasePlatform {
 
     screenCaptureErrorString() {
         return null;
+    }
+
+    requestNotificationPermission() : Promise {
+        return q('granted');
     }
 }


### PR DESCRIPTION
Merge the notification part of https://github.com/vector-im/riot-web/pull/2960

 * Show and focus the window when the notification is clicked,
   rather than just restoring it.
 * Implement requestNotificationPermission and return a resolved
   promise (although in practice it should never be called)