### PR TITLE
Add electron tray icon

### DIFF
--- a/electron/src/electron-main.js
+++ b/electron/src/electron-main.js
@@ -26,6 +26,8 @@ if (check_squirrel_hooks()) return;
 const electron = require('electron');
 const url = require('url');
 
+const tray = require('./tray');
+
 const VectorMenu = require('./vectormenu');
 
 let vectorConfig = {};
@@ -180,6 +182,12 @@ electron.app.on('ready', () => {
     mainWindow.loadURL(`file://${__dirname}/../../webapp/index.html`);
     electron.Menu.setApplicationMenu(VectorMenu);
 
+    // Create trayIcon icon
+    tray.create(mainWindow, {
+        icon_path: icon_path,
+        brand: vectorConfig.brand || 'Riot'
+    });
+
     mainWindow.once('ready-to-show', () => {
         mainWindow.show();
     });
@@ -187,7 +195,7 @@ electron.app.on('ready', () => {
         mainWindow = null;
     });
     mainWindow.on('close', (e) => {
-        if (process.platform == 'darwin' && !appQuitting) {
+        if (!appQuitting && (tray.hasTray() || process.platform == 'darwin')) {
             // On Mac, closing the window just hides it
             // (this is generally how single-window Mac apps
             // behave, eg. Mail.app)

--- a/electron/src/tray.js
+++ b/electron/src/tray.js
@@ -1,0 +1,67 @@
+/*
+Copyright 2017 Karl Glatz <karl@glatz.biz>
+Copyright 2017 OpenMarket Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+const path = require('path');
+const electron = require('electron');
+
+const app = electron.app;
+const Tray = electron.Tray;
+const MenuItem = electron.MenuItem;
+
+let trayIcon = null;
+
+exports.hasTray = function hasTray() {
+    return (trayIcon !== null);
+}
+
+exports.create = function (win, config) {
+    // no trays on darwin
+    if (process.platform === 'darwin' || trayIcon) {
+        return;
+    }
+
+    const toggleWin = function () {
+        if (win.isVisible() && !win.isMinimized()) {
+            win.hide();
+        } else {
+            if (win.isMinimized()) win.restore();
+            if (!win.isVisible()) win.show();
+            win.focus();
+        }
+    };
+
+    const contextMenu = electron.Menu.buildFromTemplate([
+        {
+            label: 'Show/Hide ' + config.brand,
+            click: toggleWin
+        },
+        {
+            type: 'separator'
+        },
+        {
+            label: 'Quit',
+            click: function () {
+                app.quit();
+            }
+        }
+    ]);
+
+    trayIcon = new Tray(config.icon_path);
+    trayIcon.setToolTip(config.brand);
+    trayIcon.setContextMenu(contextMenu);
+    trayIcon.on('click', toggleWin);
+};


### PR DESCRIPTION
From https://github.com/vector-im/riot-web/pull/2960

Makes riot minimise to the tray on windows / linux.