### PR TITLE
Make riot desktop single instance

### DIFF
--- a/electron/src/electron-main.js
+++ b/electron/src/electron-main.js
@@ -159,6 +159,19 @@ electron.ipcMain.on('install_update', installUpdate);
 
 electron.app.commandLine.appendSwitch('--enable-usermedia-screen-capturing');
 
+const shouldQuit = electron.app.makeSingleInstance((commandLine, workingDirectory) => {
+    // Someone tried to run a second instance, we should focus our window.
+    if (mainWindow) {
+        if (!mainWindow.isVisible()) mainWindow.show();
+        if (mainWindow.isMinimized()) mainWindow.restore();
+        mainWindow.focus();
+    }
+});
+
+if (shouldQuit) {
+    electron.app.quit()
+}
+
 electron.app.on('ready', () => {
     if (vectorConfig.update_base_url) {
         console.log("Starting auto update with base URL: " + vectorConfig.update_base_url);


### PR DESCRIPTION
So launching a new instance will focus the old one, meaning that
if you have Riot minimised to the tray and launch it via the
desktop shortcut / start menu, you don't end up with more & more
copies of the app.

This doesn't really prevent you from running multiple copies of
the app to fake multi account support since they share a data
directory anyway.