### PR TITLE
Add StartupWMClass

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,7 +146,10 @@
     ],
     "linux": {
       "target": "deb",
-      "maintainer": "support@riot.im"
+      "maintainer": "support@riot.im",
+      "desktop": {
+          "StartupWMClass": "riot-web"
+      }
     },
     "win": {
       "target": "squirrel"


### PR DESCRIPTION
so GNOME doesn't get confused by the hidden windows

From https://github.com/vector-im/riot-web/pull/2960