### PR TITLE
Fix link to image for event options menu

### DIFF
--- a/src/skins/vector/css/themes/_base.scss
+++ b/src/skins/vector/css/themes/_base.scss
@@ -88,7 +88,7 @@ $event-notsent-color: #f44;
 // event timestamp
 $event-timestamp-color: #acacac;
 
-$edit-button-url: "/img/icon_context_message.svg";
+$edit-button-url: "../../img/icon_context_message.svg";
 
 // e2e
 $e2e-verified-color: #76cfa5; // N.B. *NOT* the same as $accent-color

--- a/src/skins/vector/css/themes/_dark.scss
+++ b/src/skins/vector/css/themes/_dark.scss
@@ -88,7 +88,7 @@ $event-notsent-color: #f44;
 // event timestamp
 $event-timestamp-color: #acacac;
 
-$edit-button-url: "/img/icon_context_message_dark.svg";
+$edit-button-url: "../../img/icon_context_message_dark.svg";
 
 // e2e
 $e2e-verified-color: #76cfa5; // N.B. *NOT* the same as $accent-color


### PR DESCRIPTION
This has to be relative, because we don't know if riot is going to be mounted at the top-level of the domain or not (it's not, on riot.im).

Links are relative to the final location of the CSS, which is under `bundles/<hash>`, so need `../..`.