### PR TITLE
Increase the max-height of the expanded status bar

### DIFF
--- a/src/skins/vector/css/matrix-react-sdk/structures/_RoomView.scss
+++ b/src/skins/vector/css/matrix-react-sdk/structures/_RoomView.scss
@@ -171,7 +171,7 @@ hr.mx_RoomView_myReadMarker {
 }
 
 .mx_RoomView_statusArea_expanded {
-    max-height: 50px;
+    max-height: 100px;
 }
 
 .mx_RoomView_statusAreaBox {


### PR DESCRIPTION
This will ensure that errors, unsent messages, etc. will be allowed enough height to display their contents from within the status bar without being chopped.

Fixes #3041