### PR TITLE
Don't use hash-named directory for dev server

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "build:dev": "node scripts/babelcheck.js && npm run build:res && npm run build:bundle:dev",
     "dist": "scripts/package.sh",
     "start:res": "node scripts/copy-res.js -w",
-    "start:js": "webpack-dev-server --output-filename=bundles/_dev_/[name].js -w --progress",
+    "start:js": "webpack-dev-server --output-filename=bundles/_dev_/[name].js --output-chunk-file=bundles/_dev_/[name].js -w --progress",
     "start:js:prod": "NODE_ENV=production webpack-dev-server -w --progress",
     "start": "node scripts/babelcheck.js && parallelshell \"npm run start:res\" \"npm run start:js\"",
     "start:prod": "parallelshell \"npm run start:res\" \"npm run start:js:prod\"",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "build:dev": "node scripts/babelcheck.js && npm run build:res && npm run build:bundle:dev",
     "dist": "scripts/package.sh",
     "start:res": "node scripts/copy-res.js -w",
-    "start:js": "webpack-dev-server -w --progress",
+    "start:js": "webpack-dev-server --output-filename=bundles/_dev_/[name].js -w --progress",
     "start:js:prod": "NODE_ENV=production webpack-dev-server -w --progress",
     "start": "node scripts/babelcheck.js && parallelshell \"npm run start:res\" \"npm run start:js\"",
     "start:prod": "parallelshell \"npm run start:res\" \"npm run start:js:prod\"",


### PR DESCRIPTION
Otherwise Chrome thinks you're working on a new file every time
you refresh and therefore closes source tabs and removes
breakpoints which is very annoying. It also allegedly makes
webpack-dev-server run out of memory because it has to remember
all the different files.