### PR TITLE
Set BaseAvatar_image bg colour = #fff

### DIFF
--- a/src/skins/vector/css/matrix-react-sdk/views/avatars/_BaseAvatar.scss
+++ b/src/skins/vector/css/matrix-react-sdk/views/avatars/_BaseAvatar.scss
@@ -31,4 +31,5 @@ limitations under the License.
 .mx_BaseAvatar_image {
     border-radius: 40px;
     vertical-align: top;
+    background-color: #fff;
 }


### PR DESCRIPTION
Fix for https://github.com/vector-im/riot-web/issues/3051