### PR TITLE
CSS tweak for email address lookup

### DIFF
--- a/src/skins/vector/css/matrix-react-sdk/views/elements/_AddressTile.scss
+++ b/src/skins/vector/css/matrix-react-sdk/views/elements/_AddressTile.scss
@@ -106,7 +106,7 @@ limitations under the License.
 }
 
 .mx_AddressTile_email.mx_AddressTile_justified {
-    width: 380px; /* name + id width */
+    width: 200px; /* same as id width */
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;


### PR DESCRIPTION
CSS tweak for https://github.com/matrix-org/matrix-react-sdk/pull/653

Makes email addresses the name width as Matrix IDs so names can be displayed to the left of them