### PR TITLE
only recalculate favicon if it changes

### DIFF
--- a/src/vector/platform/ElectronPlatform.js
+++ b/src/vector/platform/ElectronPlatform.js
@@ -58,6 +58,7 @@ function platformFriendlyName() {
 
 export default class ElectronPlatform extends VectorBasePlatform {
     setNotificationCount(count: number) {
+        if (this.notificationCount === number) return;
         super.setNotificationCount(count);
         // this sometimes throws because electron is made of fail:
         // https://github.com/electron/electron/issues/7351

--- a/src/vector/platform/WebPlatform.js
+++ b/src/vector/platform/WebPlatform.js
@@ -60,11 +60,13 @@ export default class WebPlatform extends VectorBasePlatform {
     }
 
     setNotificationCount(count: number) {
+        if (this.notificationCount === number) return;
         super.setNotificationCount(count);
         this._updateFavicon();
     }
 
     setErrorStatus(errorDidOccur: boolean) {
+        if (this.errorDidOccur === errorDidOccur) return;
         super.setErrorStatus(errorDidOccur);
         this._updateFavicon();
     }


### PR DESCRIPTION
this is a brute force fix to lots of emitted sync events causing tonnes of:

"WebPlatform.js:58 Failed to set badge count: Error setting badge. Message: Too many badges requests in queue."

it's an open question as to why we are seeing so many sync events, though, which seem to outnumber the number of /sync responses.