### PR TITLE
Tweak desktop instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ To run as a desktop app:
 
 1. Follow the instructions in 'Building From Source' above
 2. Install electron and run it:
+
    ```
    npm install electron
    node_modules/.bin/electron .

--- a/README.md
+++ b/README.md
@@ -113,12 +113,13 @@ pre-built version from https://riot.im/desktop.html or, if you prefer,
 built it yourself.
 
 To run as a desktop app:
-```
-npm install
-npm install electron
-npm run build
-node_modules/.bin/electron .
-```
+
+ 1. Follow the instructions in 'Building From Source' above
+ 2.
+    ```
+    npm install electron
+    node_modules/.bin/electron .
+    ```
 
 To build packages, use electron-builder. This is configured to output:
  * dmg + zip for macOS
@@ -141,11 +142,9 @@ npm run build:electron
 
 For other packages, use electron-builder manually. For example, to build a package
 for 64 bit Linux:
-```
-npm install
-npm run build
-node_modules/.bin/build -l --x64
-```
+
+ 1. Follow the instructions in 'Building From Source' above
+ 2. `node_modules/.bin/build -l --x64`
 
 All electron packages go into `electron/dist/`
 

--- a/README.md
+++ b/README.md
@@ -116,10 +116,10 @@ To run as a desktop app:
 
 1. Follow the instructions in 'Building From Source' above
 2. Install electron and run it:
-    ```
-    npm install electron
-    node_modules/.bin/electron .
-    ```
+   ```
+   npm install electron
+   node_modules/.bin/electron .
+   ```
 
 To build packages, use electron-builder. This is configured to output:
  * dmg + zip for macOS

--- a/README.md
+++ b/README.md
@@ -114,8 +114,8 @@ built it yourself.
 
 To run as a desktop app:
 
- 1. Follow the instructions in 'Building From Source' above
- 2.
+1. Follow the instructions in 'Building From Source' above
+2. Install electron and run it:
     ```
     npm install electron
     node_modules/.bin/electron .


### PR DESCRIPTION
to make it clear you need to do all the things in 'building from
source', including the build-react-sdk dance if you're building
develop.