### PR TITLE
Bug report server script

### DIFF
--- a/scripts/rageshake.go
+++ b/scripts/rageshake.go
@@ -85,7 +85,7 @@ func main() {
 		//  "bugreport-20170115-112233-0.log.gz" => most recent log
 		//  "bugreport-20170115-112233-1.log.gz" => ...
 		//  "bugreport-20170115-112233-N.log.gz" => oldest log
-		t := time.Now()
+		t := time.Now().UTC()
 		prefix := t.Format("bugreport-20060102-150405")
 		summary := fmt.Sprintf(
 			"%s\n\nNumber of logs: %d\nVersion: %s\nUser-Agent: %s\n", p.Text, len(p.Logs), p.Version, p.UserAgent,

--- a/scripts/rageshake.go
+++ b/scripts/rageshake.go
@@ -37,6 +37,9 @@ func respond(code int, w http.ResponseWriter) {
 }
 
 func gzipAndSave(data []byte, filepath string) error {
+	if _, err := os.Stat(filepath); err == nil {
+		return fmt.Errorf("file already exists") // the user can just retry
+	}
 	var b bytes.Buffer
 	gz := gzip.NewWriter(&b)
 	if _, err := gz.Write(data); err != nil {

--- a/scripts/rageshake.go
+++ b/scripts/rageshake.go
@@ -1,0 +1,53 @@
+// Run a web server capable of dumping bug reports sent by Riot.
+// Requires Go 1.5+
+// Usage:   go run rageshake.go PORT
+// Example: go run rageshake.go 8080
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+)
+
+type LogEntry struct {
+	ID    string `json:"id"`
+	Lines string `json:"lines"`
+}
+
+type Payload struct {
+	Text      string     `json:"text"`
+	Version   string     `json:"version"`
+	UserAgent string     `json:"user_agent"`
+	Logs      []LogEntry `json:"logs"`
+}
+
+func main() {
+	http.HandleFunc("/", func(w http.ResponseWriter, req *http.Request) {
+		if req.Method != "POST" && req.Method != "OPTIONS" {
+			w.WriteHeader(405)
+			return
+		}
+        // Set CORS
+        w.Header().Set("Access-Control-Allow-Origin", "*")
+        w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
+        w.Header().Set("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept")
+        if req.Method == "OPTIONS" {
+            return;
+        }
+		var p Payload
+		if err := json.NewDecoder(req.Body).Decode(&p); err != nil {
+			w.WriteHeader(400)
+			w.Write([]byte("Body is not JSON"))
+			return
+		}
+        // Dump bug report to disk
+		fmt.Println(p)
+
+	})
+
+	port := os.Args[1]
+	log.Fatal(http.ListenAndServe(":"+port, nil))
+}

--- a/scripts/rageshake.go
+++ b/scripts/rageshake.go
@@ -5,12 +5,18 @@
 package main
 
 import (
+	"bytes"
+	"compress/gzip"
 	"encoding/json"
-	"fmt"
+	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
+	"strconv"
+	"time"
 )
+
+var maxPayloadSize = 1024 * 1024 * 55 // 55 MB
 
 type LogEntry struct {
 	ID    string `json:"id"`
@@ -24,28 +30,64 @@ type Payload struct {
 	Logs      []LogEntry `json:"logs"`
 }
 
+func respond(code int, w http.ResponseWriter) {
+	w.WriteHeader(code)
+	w.Write([]byte("{}"))
+}
+
+func gzipAndSave(data []byte, filepath string) error {
+	var b bytes.Buffer
+	gz := gzip.NewWriter(&b)
+	if _, err := gz.Write(data); err != nil {
+		return err
+	}
+	if err := gz.Flush(); err != nil {
+		return err
+	}
+	if err := gz.Close(); err != nil {
+		return err
+	}
+	if err := ioutil.WriteFile(filepath, b.Bytes(), 0644); err != nil {
+		return err
+	}
+	return nil
+}
+
 func main() {
 	http.HandleFunc("/", func(w http.ResponseWriter, req *http.Request) {
 		if req.Method != "POST" && req.Method != "OPTIONS" {
-			w.WriteHeader(405)
+			respond(405, w)
 			return
 		}
-        // Set CORS
-        w.Header().Set("Access-Control-Allow-Origin", "*")
-        w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
-        w.Header().Set("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept")
-        if req.Method == "OPTIONS" {
-            return;
-        }
+		// Set CORS
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept")
+		if req.Method == "OPTIONS" {
+			respond(200, w)
+			return
+		}
+		if length, err := strconv.Atoi(req.Header.Get("Content-Length")); err != nil || length > maxPayloadSize {
+			respond(413, w)
+			return
+		}
 		var p Payload
 		if err := json.NewDecoder(req.Body).Decode(&p); err != nil {
-			w.WriteHeader(400)
-			w.Write([]byte("Body is not JSON"))
+			respond(400, w)
 			return
 		}
-        // Dump bug report to disk
-		fmt.Println(p)
-
+		// Dump bug report to disk as form:
+		//  "bugreport-20170115-112233.log.gz" => user text, version, user agent, # logs
+		//  "bugreport-20170115-112233-0.log.gz" => most recent log
+		//  "bugreport-20170115-112233-1.log.gz" => ...
+		//  "bugreport-20170115-112233-N.log.gz" => oldest log
+		t := time.Now()
+		prefix := t.Format("bugreport-20060102-150405")
+		if err := gzipAndSave([]byte(p.Text), prefix+".log.gz"); err != nil {
+			respond(500, w)
+			return
+		}
+		respond(200, w)
 	})
 
 	port := os.Args[1]


### PR DESCRIPTION
Example logs (`-0` is most recent, `-3` is oldest):

```
$ ls -l
-rw-r--r--  1 kegan  staff   909 26 Jan 11:46 bugreport-20170126-114615-0.log.gz
-rw-r--r--  1 kegan  staff   524 26 Jan 11:46 bugreport-20170126-114615-1.log.gz
-rw-r--r--  1 kegan  staff  1761 26 Jan 11:46 bugreport-20170126-114615-2.log.gz
-rw-r--r--  1 kegan  staff   998 26 Jan 11:46 bugreport-20170126-114615-3.log.gz
-rw-r--r--  1 kegan  staff   198 26 Jan 11:46 bugreport-20170126-114615.log.gz

$ zless bugreport-20170126-114615.log.gz 
everything is awful.

Number of logs: 4
Version: UNKNOWN
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.95 Safari/537.36

$ zless bugreport-20170126-114615-0.log.gz 
2017-01-26T10:52:37.374Z I Initialised rageshake: See https://bugs.chromium.org/p/chromium/issues/detail?id=583193 to fix line numbers on Chrome.
2017-01-26T10:52:37.376Z I Vector starting at http://localhost:8080/#/room/!OvylurBpcFVXBQyEGv:localhost
2017-01-26T10:52:37.400Z I Routing URL http://localhost:8080/#/room/!OvylurBpcFVXBQyEGv:localhost
2017-01-26T10:52:37.408Z I Restoring session for %s @foobar2:localhost
2017-01-26T10:52:37.408Z I setLoggedIn => %s (guest=%s) hs=%s @foobar2:localhost false http://localhost:8008
2017-01-26T10:52:37.409Z I Session persisted for %s @foobar2:localhost
2017-01-26T10:52:37.549Z I SyncApi.sync: starting with sync token null
2017-01-26T10:52:37.554Z E Failed to poll for update [object Object]
2017-01-26T10:52:37.560Z I newscreen 
2017-01-26T10:52:37.573Z I Presence: %s online
2017-01-26T10:52:37.574Z I Got push rules
2017-01-26T10:52:37.677Z I MatrixClient sync state => %s PREPARED
2017-01-26T10:52:37.681Z I MatrixClient sync state => %s SYNCING
2017-01-26T10:52:37.683Z I newscreen room/!OvylurBpcFVXBQyEGv:localhost
2017-01-26T10:52:37.943Z I updateTint from RoomView._gatherTimelinePanelRef
2017-01-26T10:52:37.945Z I Tinter.tint from updateTint
2017-01-26T10:52:40.650Z I newscreen settings
2017-01-26T10:52:40.821Z I Failed to fetch app version [object Object]
2017-01-26T10:52:45.674Z I Sending bug report.
2017-01-26T10:52:48.065Z E Warning: setState(...): Can only update a mounted or mounting component. This usually means you called setState() on an unmounted component. This is a no-op. Please check the code for the RoomView component.
2017-01-26T10:56:30.634Z I Presence: %s unavailable
2017-01-26T11:02:38.610Z E Failed to poll for update [object Object]
2017-01-26T11:10:12.410Z I Presence: %s online
2017-01-26T11:10:15.215Z I Sending bug report.
...
```
