### PR TITLE
Fix the width of input fields within login/reg box

### DIFF
--- a/src/skins/vector/css/matrix-react-sdk/structures/login/_Login.scss
+++ b/src/skins/vector/css/matrix-react-sdk/structures/login/_Login.scss
@@ -45,7 +45,7 @@ limitations under the License.
 }
 
 .mx_Login_field {
-    width: 100%;
+    width: 280px;
     border-radius: 3px;
     border: 1px solid $strong-input-border-color;
     font-weight: 300;


### PR DESCRIPTION
This is so they do not expand outside of the login area. (280px = 300px - 2px - 18px, 2px for borders, 18px for padding)