### PR TITLE
Fix jenkins build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ node_js:
 install:
     - npm install
     - (cd node_modules/matrix-js-sdk && npm install)
-    - (cd node_modules/matrix-react-sdk && npm run build)
+    - (cd node_modules/matrix-react-sdk && npm install)

--- a/scripts/jenkins.sh
+++ b/scripts/jenkins.sh
@@ -20,8 +20,8 @@ rm -r node_modules/olm
 cp -r olm/package node_modules/olm
 
 # we may be using dev branches of js-sdk and react-sdk, in which case we need to build them
-(cd node_modules/matrix-js-sdk && npm run build)
-(cd node_modules/matrix-react-sdk && npm run build)
+(cd node_modules/matrix-js-sdk && npm install)
+(cd node_modules/matrix-react-sdk && npm install)
 
 # run the mocha tests
 npm run test


### PR DESCRIPTION
Do `npm install` on js-sdk rather than `npm run build`, which will hopefully
mean that `browserify` gets installed before we try to run it.

The README says we should use `npm install` for the react-sdk too, so let's do
that, and bring the travis and jenkins builds into sync with the README.