### PR TITLE
Handle icons with width > height

### DIFF
--- a/src/skins/vector/css/matrix-react-sdk/structures/login/_Login.scss
+++ b/src/skins/vector/css/matrix-react-sdk/structures/login/_Login.scss
@@ -46,7 +46,7 @@ limitations under the License.
 }
 
 .mx_Login_logo img {
-    height: 100%
+    max-height: 100%
 }
 
 .mx_Login_support {


### PR DESCRIPTION
Icons with width > height will now only assume a max-height of 100% as opposed to a height of 100%. This is so they don't overflow the width of 300px.

Before:
![2017-02-02-113238_518x528_scrot](https://cloud.githubusercontent.com/assets/6750344/22547797/5c6d1a00-e93b-11e6-96a2-ad0892a8c7f7.png)

After:
![2017-02-02-113252_407x408_scrot](https://cloud.githubusercontent.com/assets/6750344/22547796/5c6c1cfe-e93b-11e6-96dc-ba63fcdd38d9.png)
