### PR TITLE
Store bug reports in separate directories

### DIFF
--- a/scripts/rageshake.go
+++ b/scripts/rageshake.go
@@ -37,8 +37,9 @@ func respond(code int, w http.ResponseWriter) {
 	w.Write([]byte("{}"))
 }
 
-func gzipAndSave(data []byte, fpath string) error {
-	fpath = filepath.Join("bugs", fpath)
+func gzipAndSave(data []byte, dirname, fpath string) error {
+	_ = os.Mkdir(filepath.Join("bugs", dirname), os.ModePerm)
+	fpath = filepath.Join("bugs", dirname, fpath)
 
 	if _, err := os.Stat(fpath); err == nil {
 		return fmt.Errorf("file already exists") // the user can just retry
@@ -93,12 +94,12 @@ func main() {
 		summary := fmt.Sprintf(
 			"%s\n\nNumber of logs: %d\nVersion: %s\nUser-Agent: %s\n", p.Text, len(p.Logs), p.Version, p.UserAgent,
 		)
-		if err := gzipAndSave([]byte(summary), prefix+".log.gz"); err != nil {
+		if err := gzipAndSave([]byte(summary), prefix, "details.log.gz"); err != nil {
 			respond(500, w)
 			return
 		}
 		for i, log := range p.Logs {
-			if err := gzipAndSave([]byte(log.Lines), fmt.Sprintf("%s-%d.log.gz", prefix, i)); err != nil {
+			if err := gzipAndSave([]byte(log.Lines), prefix, fmt.Sprintf("logs-%d.log.gz", i)); err != nil {
 				respond(500, w)
 				return // TODO: Rollback?
 			}

--- a/scripts/rageshake.go
+++ b/scripts/rageshake.go
@@ -38,7 +38,7 @@ func respond(code int, w http.ResponseWriter) {
 }
 
 func gzipAndSave(data []byte, dirname, fpath string) error {
-	_ = os.Mkdir(filepath.Join("bugs", dirname), os.ModePerm)
+	_ = os.MkdirAll(filepath.Join("bugs", dirname), os.ModePerm)
 	fpath = filepath.Join("bugs", dirname, fpath)
 
 	if _, err := os.Stat(fpath); err == nil {
@@ -90,7 +90,7 @@ func main() {
 		//  "bugreport-20170115-112233-1.log.gz" => ...
 		//  "bugreport-20170115-112233-N.log.gz" => oldest log
 		t := time.Now().UTC()
-		prefix := t.Format("bugreport-20060102-150405")
+		prefix := t.Format("2006-01-02/150405")
 		summary := fmt.Sprintf(
 			"%s\n\nNumber of logs: %d\nVersion: %s\nUser-Agent: %s\n", p.Text, len(p.Logs), p.Version, p.UserAgent,
 		)
@@ -106,6 +106,9 @@ func main() {
 		}
 		respond(200, w)
 	})
+
+	// Make sure bugs directory exists
+	_ = os.Mkdir("bugs", os.ModePerm)
 
 	port := os.Args[1]
 	log.Fatal(http.ListenAndServe(":"+port, nil))


### PR DESCRIPTION
And remove the long filenames now that there is a directory above them.