### PR TITLE
Float the toggle in the top right of MELS

### DIFF
--- a/src/skins/vector/css/matrix-react-sdk/views/elements/_MemberEventListSummary.scss
+++ b/src/skins/vector/css/matrix-react-sdk/views/elements/_MemberEventListSummary.scss
@@ -14,6 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+.mx_MemberEventListSummary {
+    position: relative;
+}
+
 .mx_TextualEvent.mx_MemberEventListSummary_summary {
     font-size: 14px;
 }
@@ -31,6 +35,15 @@ limitations under the License.
 }
 
 .mx_MemberEventListSummary_toggle {
-    color:$accent-color;
-    cursor:pointer;
+    color: $accent-color;
+    cursor: pointer;
+    float: right;
+    margin-right: 10px;
+    margin-top: 8px;
+}
+
+.mx_MemberEventListSummary_line {
+    border-bottom: 1px solid $primary-hairline-color;
+    margin-left: 63px;
+    line-height: 30px;
 }


### PR DESCRIPTION
This is so that it stays put when the MELS is toggled.

Added style for a line that appears below "collapse" to indicate start of events.

Not possible to put "collapse" next to the expanded events because of read receipts.

Complements https://github.com/matrix-org/matrix-react-sdk/pull/683