### PR TITLE
Reposition certain icons in the status bar

### DIFF
--- a/src/skins/vector/css/matrix-react-sdk/structures/_RoomStatusBar.scss
+++ b/src/skins/vector/css/matrix-react-sdk/structures/_RoomStatusBar.scss
@@ -16,7 +16,7 @@ limitations under the License.
 
 .mx_RoomStatusBar {
     margin-left: 65px;
-    min-height: 34px;
+    min-height: 50px;
 }
 
 /* position the indicator in the same place horizontally as .mx_EventTile_avatar. */
@@ -24,7 +24,7 @@ limitations under the License.
     padding-left: 17px;
     padding-right: 12px;
     margin-left: -73px;
-    margin-top: 8px;
+    margin-top: 15px;
     float: left;
     width: 24px;
     text-align: center;
@@ -72,6 +72,7 @@ limitations under the License.
 
 .mx_RoomStatusBar_typingIndicatorAvatars {
     width: 52px;
+    margin-top: -1px;
     text-align: left;
 }
 
@@ -102,6 +103,7 @@ limitations under the License.
 
 .mx_RoomStatusBar_scrollDownIndicator {
     cursor: pointer;
+    padding-left: 1px;
 }
 
 .mx_RoomStatusBar_unreadMessagesBar {
@@ -144,7 +146,9 @@ limitations under the License.
 }
 
 .mx_RoomStatusBar_typingBar {
-    padding-top: 10px;
+    height: 50px;
+    line-height: 50px;
+
     color: $primary-fg-color;
     opacity: 0.5;
     overflow-y: hidden;

--- a/src/skins/vector/css/matrix-react-sdk/structures/_RoomView.scss
+++ b/src/skins/vector/css/matrix-react-sdk/structures/_RoomView.scss
@@ -207,10 +207,12 @@ hr.mx_RoomView_myReadMarker {
 
 .mx_RoomView_inCall .mx_RoomView_statusAreaBox_line {
     border-top: 1px hidden;
+    padding-top: 1px;
 }
 
 .mx_RoomView_inCall .mx_MessageComposer_wrapper {
     border-top: 2px hidden;
+    padding-top: 1px;
 }
 
 .mx_RoomView_inCall .mx_RoomView_statusAreaBox {


### PR DESCRIPTION
Also, make sure the typing avatars line up with the arrow to jump to the bottom of the timeline.
Also, get rid of any height jumps when a call starts. border 1px hidden does not add any height to an element, it is effectively the same as none.

Fixes https://github.com/vector-im/riot-web/issues/3096, https://github.com/vector-im/riot-web/issues/3037