### PR TITLE
Remove z-index property on avatar initials

### DIFF
--- a/src/skins/vector/css/matrix-react-sdk/views/avatars/_BaseAvatar.scss
+++ b/src/skins/vector/css/matrix-react-sdk/views/avatars/_BaseAvatar.scss
@@ -20,7 +20,6 @@ limitations under the License.
 
 .mx_BaseAvatar_initial {
     position: absolute;
-    z-index: 1;
     color: $avatar-initial-color;
     text-align: center;
     speak: none;


### PR DESCRIPTION
This seemingly doesn't do anything and upsets things when avatars overlap (i.e. for the new typing avatars).

See https://github.com/matrix-org/matrix-react-sdk/pull/699