### PR TITLE
Fix broken tests caused by adding IndexedDB support

### DIFF
--- a/test/app-tests/joining.js
+++ b/test/app-tests/joining.js
@@ -95,7 +95,10 @@ describe('joining a room', function () {
             });
 
             var roomView;
-            httpBackend.flush().then(() => {
+            // wait for /sync to happen
+            return q.delay(1).then(() => {
+                return httpBackend.flush();
+            }).then(() => {
                 var roomDir = ReactTestUtils.findRenderedComponentWithType(
                     matrixChat, RoomDirectory);
 


### PR DESCRIPTION
This test assumed that `/sync` would be called immediately after rendering
`<MatrixChat />` but this isn't true in an IndexedDB world: it bounces via
`store.startup()` first.

It looks like the tests resolve this by adding `q.delay(1)` so that's what
I've done: in the future it would be better to extend `HttpBackend` to have
a `waitFor(req) Promise` function so we can removing timing from the tests.