### PR TITLE
Height:100% for welcome pages on Safari

### DIFF
--- a/src/skins/vector/css/matrix-react-sdk/structures/_MatrixChat.scss
+++ b/src/skins/vector/css/matrix-react-sdk/structures/_MatrixChat.scss
@@ -100,6 +100,11 @@ limitations under the License.
      * flex itself.
      */
     display: flex;
+
+    /* To fix https://github.com/vector-im/riot-web/issues/3298 where Safari
+       needed height 100% all the way down to the HomePage.
+    */
+    height: 100%;
 }
 
 .mx_MatrixChat .mx_RightPanel {

--- a/src/skins/vector/css/matrix-react-sdk/structures/_MatrixChat.scss
+++ b/src/skins/vector/css/matrix-react-sdk/structures/_MatrixChat.scss
@@ -90,19 +90,11 @@ limitations under the License.
        */
     overflow-x: auto;
 
-    /* XXX: Hack: apparently if you try to nest a flex-box
-     * within a non-flex-box within a flex-box, the height
-     * of the innermost element gets miscalculated if the
-     * parents are both auto.  Height has to be auto here
-     * for RoomView to correctly fit when the Toolbar is shown.
-     * Ideally we'd launch straight into the RoomView at this
-     * point, but instead we fudge it and make the middlePanel
-     * flex itself.
-     */
     display: flex;
 
     /* To fix https://github.com/vector-im/riot-web/issues/3298 where Safari
-       needed height 100% all the way down to the HomePage.
+       needed height 100% all the way down to the HomePage. Height does not
+       have to be auto, empirically.
     */
     height: 100%;
 }

--- a/src/skins/vector/css/vector-web/structures/_HomePage.scss
+++ b/src/skins/vector/css/vector-web/structures/_HomePage.scss
@@ -18,6 +18,8 @@ limitations under the License.
 .mx_HomePage {
     max-width: 960px;
     width: 100%;
+    height: 100%;
+    overflow-y: hidden;
     margin-left: auto;
     margin-right: auto;
 }


### PR DESCRIPTION
Fix for vector-im/riot-web#3298

This seems to not have any side-effects.