### PR TITLE
Hide statusAreaBox_line entirely when inCall

### DIFF
--- a/src/skins/vector/css/matrix-react-sdk/structures/_RoomView.scss
+++ b/src/skins/vector/css/matrix-react-sdk/structures/_RoomView.scss
@@ -206,8 +206,9 @@ hr.mx_RoomView_myReadMarker {
 }
 
 .mx_RoomView_inCall .mx_RoomView_statusAreaBox_line {
-    border-top: 1px hidden;
-    padding-top: 1px;
+    margin-top: 2px;
+    border: none;
+    height: 0px;
 }
 
 .mx_RoomView_inCall .mx_MessageComposer_wrapper {


### PR DESCRIPTION
This is to keep things vertically balanced.

Fixes https://github.com/vector-im/riot-web/issues/3269