### PR TITLE
Set padding-bottom: 0px for .mx_Dialog spinner

### DIFF
--- a/src/skins/vector/css/_common.scss
+++ b/src/skins/vector/css/_common.scss
@@ -136,6 +136,7 @@ textarea {
     width: auto;
     border-radius: 8px;
     padding-left: 0px;
+    padding-bottom: 0px;
     box-shadow: none;
 }
 

--- a/src/skins/vector/css/_common.scss
+++ b/src/skins/vector/css/_common.scss
@@ -135,8 +135,7 @@ textarea {
 .mx_Dialog_wrapper.mx_Dialog_spinner .mx_Dialog {
     width: auto;
     border-radius: 8px;
-    padding-left: 0px;
-    padding-bottom: 0px;
+    padding: 0px;
     box-shadow: none;
 }
 


### PR DESCRIPTION
This was causing https://github.com/vector-im/riot-web/issues/3226