### PR TITLE
Better CSS for redactions

### DIFF
--- a/src/components/views/context_menus/MessageContextMenu.js
+++ b/src/components/views/context_menus/MessageContextMenu.js
@@ -121,7 +121,7 @@ module.exports = React.createClass({
             );
         }
 
-        if (!eventStatus) { // sent
+        if (!eventStatus && !this.props.mxEvent.isRedacted()) { // sent and not redacted
             redactButton = (
                 <div className="mx_MessageContextMenu_field" onClick={this.onRedactClick}>
                     Redact

--- a/src/skins/vector/css/matrix-react-sdk/views/rooms/_EventTile.scss
+++ b/src/skins/vector/css/matrix-react-sdk/views/rooms/_EventTile.scss
@@ -130,14 +130,13 @@ limitations under the License.
     color: $event-notsent-color;
 }
 
-.mx_EventTile_redacted {
-    padding-top: 0px;
-}
-
-.mx_EventTile_redacted .mx_EventTile_line,
-.mx_EventTile_redacted:hover .mx_EventTile_line,
-.mx_EventTile_redacted.menu .mx_EventTile_line {
-    background-color: $primary-fg-color;
+.mx_EventTile_redacted .mx_EventTile_line .mx_UnknownBody {
+    display: block;
+    width: 100%;
+    max-width: 300px;
+    height: 24px;
+    border-radius: 4px;
+    background-color: black;
 }
 
 .mx_EventTile_highlight,


### PR DESCRIPTION
Fixes part of https://github.com/vector-im/riot-web/issues/3390

Also: The "Redact" option in the MessageContextMenu no longer appears for redacted events.

Screenshots:

(before)
![2017-03-16-165849_627x230_scrot](https://cloud.githubusercontent.com/assets/6750344/24008823/b9cbc458-0a6a-11e7-826a-f28eef90da69.png)

(after)
![2017-03-16-170604_613x174_scrot](https://cloud.githubusercontent.com/assets/6750344/24008873/f1e23c46-0a6a-11e7-8c2c-45a78277471f.png)

