### PR TITLE
dark theme invert inconsistent across browsers

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -10,3 +10,6 @@ include:
 
 * Florent VIOLLEAU (https://github.com/floviolleau) <floviolleau at gmail dot com>
   Improve README.md for a better understanding of installation instructions
+
+* Michael Telatynski (https://github.com/t3chguy)
+  Improved consistency of inverted elements in dark theme across browsers

--- a/src/skins/vector/css/themes/_dark.scss
+++ b/src/skins/vector/css/themes/_dark.scss
@@ -115,17 +115,17 @@ $progressbar-color: #000;
 // better match the theme.  Typically applied to dark grey 'off' buttons or
 // light grey 'on' buttons.
 .mx_filterFlipColor {
-    filter: invert();
+    filter: invert(1);
 }
 
 .gm-scrollbar .thumb {
-    filter: invert();
+    filter: invert(1);
 }
 
 // markdown overrides:
 .mx_EventTile_content .markdown-body {
     pre, code {
-        filter: invert();
+        filter: invert(1);
     }
 
     pre code {


### PR DESCRIPTION
fixes #3433 

`-webkit-filter::invert` (generated) seems to default to `invert(1)`
`whereas filter::invert` is [documented](https://developer.mozilla.org/en/docs/Web/CSS/filter) to default to `invert(0)` (no inversion)