### PR TITLE
Rename ReactPerf to Perf

### DIFF
--- a/src/vector/index.js
+++ b/src/vector/index.js
@@ -50,7 +50,7 @@ rageshake.init().then(() => {
  // access via the console
 global.React = require("react");
 if (process.env.NODE_ENV !== 'production') {
-    global.ReactPerf = require("react-addons-perf");
+    global.Perf = require("react-addons-perf");
 }
 
 var RunModernizrTests = require("./modernizr"); // this side-effects a global


### PR DESCRIPTION
As this makes it work out of the box with react-perf chrome
extension (which doesn't do a whole lot other than save you having
to remember the commands, but is still quite nice).