### PR TITLE
Escape HTML Tags from Linux Notifications (electron)

### DIFF
--- a/src/vector/platform/ElectronPlatform.js
+++ b/src/vector/platform/ElectronPlatform.js
@@ -86,6 +86,8 @@ export default class ElectronPlatform extends VectorBasePlatform {
         // Electron Docs state all supported linux notification systems follow this markup spec
         // https://github.com/electron/electron/blob/master/docs/tutorial/desktop-environment-integration.md#linux
         // maybe we should pass basic styling (italics, bold, underline) through from MD
+        // we only have to strip out < and > as the spec doesn't include anything about things like &amp;
+        // so we shouldn't assume that all implementations will treat those properly. Very basic tag parsing is done.
         if (window.process.platform === 'linux') {
             msg = msg.replace(/</g, "&lt;").replace(/>/g, "&gt;");
         }

--- a/src/vector/platform/ElectronPlatform.js
+++ b/src/vector/platform/ElectronPlatform.js
@@ -81,6 +81,15 @@ export default class ElectronPlatform extends VectorBasePlatform {
     }
 
     displayNotification(title: string, msg: string, avatarUrl: string, room: Object): Notification {
+
+        // GNOME notification spec parses HTML tags for styling...
+        // Electron Docs state all supported linux notification systems follow this markup spec
+        // https://github.com/electron/electron/blob/master/docs/tutorial/desktop-environment-integration.md#linux
+        // maybe we should pass basic styling (italics, bold, underline) through from MD
+        if (window.process.platform === 'linux') {
+            msg = msg.replace(/</g, "&lt;").replace(/>/g, "&gt;");
+        }
+
         // Notifications in Electron use the HTML5 notification API
         const notification = new global.Notification(
             title,


### PR DESCRIPTION
https://developer.gnome.org/notification-spec/ lists HTML tags which cause special behaviour, but KDE/Plasma for instance simply removes anything that looks like a HTML Tag, https://github.com/electron/electron/blob/master/docs/tutorial/desktop-environment-integration.md#linux says that all Electron supported Linux notification systems (via libnotify) follow this markup spec. Examples of how this issue manifests below:

![screenshot_20170403_103437](https://cloud.githubusercontent.com/assets/2403652/24662730/e509d92e-194d-11e7-85d3-ba98a22da4f8.png)

After fix (different message, this data would previously be in italics):

![screenshot_20170403_105057](https://cloud.githubusercontent.com/assets/2403652/24662744/ee772656-194d-11e7-8171-2b53511cff05.png)

---

Tested on Windows for sanity's sake
Tested on KDE Neon (KDE/Plasma) 16.04

Needs testing on some other DMs/Distros

Sample test data:
+ `<i>Foo</i>`
+ `<hello>`