### PR TITLE
Add support for indexeddb sync in webworker

### DIFF
--- a/src/vector/index.html
+++ b/src/vector/index.html
@@ -37,8 +37,19 @@
   <body style="height: 100%;">
     <section id="matrixchat" style="height: 100%;"></section>
     <noscript>Sorry, Riot requires JavaScript to be enabled.</noscript>
-    <% for (var i=0; i < htmlWebpackPlugin.files.js.length; i++) {%>
-       <script src="<%= htmlWebpackPlugin.files.js[i] %>"></script>
+    <% for (var i=0; i < htmlWebpackPlugin.files.js.length; i++) {
+        // Not a particularly graceful way of not putting the indexeddb worker script
+        // into the main page
+        if (htmlWebpackPlugin.files.js[i].endsWith('indexeddb-worker.js')) {
+            %>
+            <script>
+                window.vector_indexeddb_worker_script = '<%= htmlWebpackPlugin.files.js[i] %>';
+            </script>
+            <%
+            continue;
+        }
+        %>
+        <script src="<%= htmlWebpackPlugin.files.js[i] %>"></script>
     <% } %>
     <img src="img/warning.svg" width="24" height="23" style="visibility: hidden; position: absolute; top: 0px; left: 0px;"/>
     <audio id="messageAudio">

--- a/src/vector/index.html
+++ b/src/vector/index.html
@@ -40,7 +40,7 @@
     <% for (var i=0; i < htmlWebpackPlugin.files.js.length; i++) {
         // Not a particularly graceful way of not putting the indexeddb worker script
         // into the main page
-        if (htmlWebpackPlugin.files.js[i].endsWith('indexeddb-worker.js')) {
+        if (_.endsWith(htmlWebpackPlugin.files.js[i], 'indexeddb-worker.js')) {
             %>
             <script>
                 window.vector_indexeddb_worker_script = '<%= htmlWebpackPlugin.files.js[i] %>';

--- a/src/vector/index.js
+++ b/src/vector/index.js
@@ -68,10 +68,14 @@ import url from 'url';
 import {parseQs, parseQsFromFragment} from './url_utils';
 import Platform from './platform';
 
+import MatrixClientPeg from 'matrix-react-sdk/lib/MatrixClientPeg';
+
 var lastLocationHashSet = null;
 
 var CallHandler = require("matrix-react-sdk/lib/CallHandler");
 CallHandler.setConferenceHandler(VectorConferenceHandler);
+
+MatrixClientPeg.setIndexedDbWorkerScript(window.vector_indexeddb_worker_script);
 
 function checkBrowserFeatures(featureList) {
     if (!window.Modernizr) {

--- a/src/vector/indexedbd-worker.js
+++ b/src/vector/indexedbd-worker.js
@@ -1,0 +1,26 @@
+/*
+Copyright 2017 Vector Creations Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// The prescribed way of doing this import would be:
+//import {IndexedDbStoreWorker} from 'matrix-js-sdk';
+// However, this still pulls in all of the js-sdk and we only use a tiny fraction
+// of it. It also causes an Olm error to appear because we don't have an Olm in scope.
+// Instead, we do this:
+import IndexedDbStoreWorker from 'matrix-js-sdk/lib/store/indexeddb-remote-worker';
+
+const remoteWorker = new IndexedDbStoreWorker(postMessage);
+
+onmessage = remoteWorker.onMessage;

--- a/src/vector/indexedbd-worker.js
+++ b/src/vector/indexedbd-worker.js
@@ -14,12 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// The prescribed way of doing this import would be:
-//import {IndexedDbStoreWorker} from 'matrix-js-sdk';
-// However, this still pulls in all of the js-sdk and we only use a tiny fraction
-// of it. It also causes an Olm error to appear because we don't have an Olm in scope.
-// Instead, we do this:
-import IndexedDBStoreWorker from 'matrix-js-sdk/lib/store/indexeddb-store-worker';
+import {IndexedDBStoreWorker} from 'matrix-js-sdk/lib/indexeddb-worker.js';
 
 const remoteWorker = new IndexedDBStoreWorker(postMessage);
 

--- a/src/vector/indexedbd-worker.js
+++ b/src/vector/indexedbd-worker.js
@@ -19,8 +19,8 @@ limitations under the License.
 // However, this still pulls in all of the js-sdk and we only use a tiny fraction
 // of it. It also causes an Olm error to appear because we don't have an Olm in scope.
 // Instead, we do this:
-import IndexedDbStoreWorker from 'matrix-js-sdk/lib/store/indexeddb-remote-worker';
+import IndexedDBStoreWorker from 'matrix-js-sdk/lib/store/indexeddb-store-worker';
 
-const remoteWorker = new IndexedDbStoreWorker(postMessage);
+const remoteWorker = new IndexedDBStoreWorker(postMessage);
 
 onmessage = remoteWorker.onMessage;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,6 +6,7 @@ var HtmlWebpackPlugin = require('html-webpack-plugin');
 module.exports = {
     entry: {
         "bundle": "./src/vector/index.js",
+        "indexeddb-worker": "./src/vector/indexedbd-worker.js",
 
         // We ship olm.js as a separate lump of javascript. This makes it get
         // loaded via a separate <script/> tag in index.html (which loads it


### PR DESCRIPTION
Provides a worker script for the js-sdk indexeddb webworker mode (https://github.com/matrix-org/matrix-js-sdk/pull/412) and enables it using https://github.com/matrix-org/matrix-react-sdk/pull/792

https://github.com/vector-im/riot-web/issues/3252