### PR TITLE
Remove LHS Div from ImageView

### DIFF
--- a/src/components/views/elements/ImageView.js
+++ b/src/components/views/elements/ImageView.js
@@ -163,8 +163,6 @@ module.exports = React.createClass({
 
         return (
             <div className="mx_ImageView">
-                <div className="mx_ImageView_lhs">
-                </div>
                 <div className="mx_ImageView_content">
                     <img src={this.props.src} style={style}/>
                     <div className="mx_ImageView_labelWrapper">

--- a/src/skins/vector/css/vector-web/views/elements/_ImageView.scss
+++ b/src/skins/vector/css/vector-web/views/elements/_ImageView.scss
@@ -25,14 +25,6 @@ limitations under the License.
     align-items: center;
 }
 
-.mx_ImageView_lhs {
-    order: 1;
-    flex: 1 1 10%;
-    min-width: 60px;
-    // background-color: #080;
-    // height: 20px;
-}
-
 .mx_ImageView_content {
     order: 2;
     /* min-width hack needed for FF */


### PR DESCRIPTION
Images will now use a lot more of the available space
but still be relatively centrered if they do not need the space
useful especially in Riot Desktop where fullscreening an image is not yet a thing

for #3638

Signed-off-by: Michael Telatynski <7t3chguy@gmail.com>

![screenshot 351](https://cloud.githubusercontent.com/assets/2403652/25072633/c690baee-22cb-11e7-95b5-0af7bcae975e.png)
