### PR TITLE
fix ImageView Download functionality

### DIFF
--- a/src/components/views/elements/ImageView.js
+++ b/src/components/views/elements/ImageView.js
@@ -176,7 +176,7 @@ module.exports = React.createClass({
                                 { this.getName() }
                             </div>
                             { eventMeta }
-                            <a className="mx_ImageView_link" href={ this.props.src } target="_blank" rel="noopener">
+                            <a className="mx_ImageView_link" href={ this.props.src } download={ this.props.name } target="_blank" rel="noopener">
                                 <div className="mx_ImageView_download">
                                         Download this file<br/>
                                          <span className="mx_ImageView_size">{ size_res }</span>


### PR DESCRIPTION
depends on matrix-org/matrix-react-sdk#802

fixes #2778 and #2970

Notes:
Right clicking "Download this file" and clicking what comes up in Electron lets you send it to Browser/Image Viewer and obviously "Open in new tab" works in browsers. Though this will not work for Encrypted Images in [only] Electron, but will in browsers which support data URIs.