### PR TITLE
Increased the emoji size to 2em

### DIFF
--- a/src/skins/vector/css/_common.scss
+++ b/src/skins/vector/css/_common.scss
@@ -269,7 +269,7 @@ textarea {
 }
 
 .mx_emojione {
-    height: 1em;
+    height: 2em;
     vertical-align: middle;
 }
 


### PR DESCRIPTION
Fixes #2890 

Its a good idea to make the emojis look more visible and vibrant. Having them on the same size as the text makes them look very small. The one very good reason to have a bigger emoji is that an emoji expresents an expression which definitely conveys information more than one ASCII character. 

![largeremojisize](https://cloud.githubusercontent.com/assets/971668/25112677/099d7eb2-23f3-11e7-8ad1-1d97ad0ac373.png)
 