### PR TITLE
rageshake: fix race when collecting logs

### DIFF
--- a/src/vector/rageshake.js
+++ b/src/vector/rageshake.js
@@ -205,9 +205,6 @@ class IndexedDBLogStore {
             }
             let txn = this.db.transaction(["logs", "logslastmod"], "readwrite");
             let objStore = txn.objectStore("logs");
-            objStore.add(this._generateLogEntry(lines));
-            let lastModStore = txn.objectStore("logslastmod");
-            lastModStore.put(this._generateLastModifiedTime());
             txn.oncomplete = (event) => {
                 resolve();
             };
@@ -219,6 +216,9 @@ class IndexedDBLogStore {
                     new Error("Failed to write logs: " + event.target.errorCode)
                 );
             }
+            objStore.add(this._generateLogEntry(lines));
+            let lastModStore = txn.objectStore("logslastmod");
+            lastModStore.put(this._generateLastModifiedTime());
         });
         return this.flushPromise;
     }


### PR DESCRIPTION
*apparently* it's possible for your indexeddb transaction to complete in the
background, so that the `oncomplete` handler is never called. Make sure that
the oncomplete handler is set *before* doing the work.