### PR TITLE
Use multipart-form encoding for rageshake uploads

### DIFF
--- a/src/vector/submit-rageshake.js
+++ b/src/vector/submit-rageshake.js
@@ -23,7 +23,7 @@ import rageshake from './rageshake'
 
 // polyfill textencoder if necessary
 import * as TextEncodingUtf8 from 'text-encoding-utf-8';
-let TextDecoder = window.TextEncoder;
+let TextEncoder = window.TextEncoder;
 if (!TextEncoder) {
     TextEncoder = TextEncodingUtf8.TextEncoder;
 }


### PR DESCRIPTION
This is a more sensible encoding for uploading logfiles, and will allow us to compress the logfiles in future.

browser-request doesn't give us enough flexibility to do this properly, so we use XMLHttpRequest directly.

See https://github.com/matrix-org/rageshake/blob/caf57b60cbfda2652fa577397aaebb4df04449f7/README.md#post-apisubmit for the API details.

(builds on top of https://github.com/vector-im/riot-web/pull/3645. The actual changes are in 0561c8c.)

