### PR TITLE
CSS to make h1 and h2 the same size as h1.

### DIFF
--- a/src/skins/vector/css/matrix-react-sdk/views/rooms/_EventTile.scss
+++ b/src/skins/vector/css/matrix-react-sdk/views/rooms/_EventTile.scss
@@ -331,6 +331,14 @@ limitations under the License.
     font-family: inherit ! important;
 }
 
+
+/* Make h1 and h2 the same size as h3. */
+.mx_EventTile_content .markdown-body h1,
+.mx_EventTile_content .markdown-body h2
+{
+    font-size: 1.5em;
+}
+
 .mx_EventTile_content .markdown-body a {
     color: $accent-color;
 }


### PR DESCRIPTION
Addresses #1772

Partnered with https://github.com/matrix-org/matrix-react-sdk/pull/820

Signed-off-by: Travis Ralston <travpc@gmail.com>