### PR TITLE
Prevent long room names/topics from pushing UI of the screen

### DIFF
--- a/src/skins/vector/css/matrix-react-sdk/views/rooms/_RoomHeader.scss
+++ b/src/skins/vector/css/matrix-react-sdk/views/rooms/_RoomHeader.scss
@@ -31,6 +31,7 @@ limitations under the License.
     margin-left: -2px;
     order: 1;
     flex: 1;
+    overflow: hidden;
 }
 
 .mx_RoomHeader_spinner {


### PR DESCRIPTION
This was causing the "save" button in RoomSettings to be obscured when room names were set to long strings without spaces

Fixes https://github.com/vector-im/riot-web/issues/1729