### PR TITLE
Warn when exiting due to single-instance

### DIFF
--- a/electron/src/electron-main.js
+++ b/electron/src/electron-main.js
@@ -171,6 +171,7 @@ const shouldQuit = electron.app.makeSingleInstance((commandLine, workingDirector
 });
 
 if (shouldQuit) {
+    console.log("Other instance detected: exiting");
     electron.app.quit()
 }
 


### PR DESCRIPTION
This lost me a fair bit of time trying to figure out why Riot was
starting and then immediately quitting.