### PR TITLE
Pin filesize ver to fix break upstream

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "draft-js": "^0.8.1",
     "extract-text-webpack-plugin": "^0.9.1",
     "favico.js": "^0.3.10",
-    "filesize": "^3.1.2",
+    "filesize": "3.5.6",
     "flux": "~2.0.3",
     "gfm.css": "^1.1.1",
     "highlight.js": "^9.0.0",


### PR DESCRIPTION
https://travis-ci.org/vector-im/riot-web/builds/227340622
avoidwork/filesize.js#87
3.5.7 and 3.5.8 ver released <24h ago and broke stuff for us

Signed-off-by: Michael Telatynski 7t3chguy@gmail.com