### PR TITLE
Use react-sdk Reskindex plugin

### DIFF
--- a/src/component-index.js
+++ b/src/component-index.js
@@ -1,5 +1,6 @@
 /*
 Copyright 2015, 2016 OpenMarket Ltd
+Copyright 2017 Vector Creations Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -19,9 +20,6 @@ limitations under the License.
  * You can edit it you like, but your changes will be overwritten,
  * so you'd just be trying to swim upstream like a salmon.
  * You are not a salmon.
- *
- * To update it, run:
- *    ./reskindex.js -h header
  */
 
 module.exports.components = require('matrix-react-sdk/lib/component-index').components;

--- a/src/header
+++ b/src/header
@@ -1,5 +1,6 @@
 /*
 Copyright 2015, 2016 OpenMarket Ltd
+Copyright 2017 Vector Creations Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,6 +2,7 @@ const path = require('path');
 const webpack = require('webpack');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
+const ReskindexPlugin = require('matrix-react-sdk/lib/utils/ReskindexPlugin');
 
 module.exports = {
     entry: {
@@ -124,6 +125,8 @@ module.exports = {
             // about moving them.
             inject: false,
         }),
+
+        new ReskindexPlugin('./node_modules/matrix-react-sdk/header'),
     ],
     devtool: 'source-map',
 


### PR DESCRIPTION
This automates that reskindexing so that running `npm run reskindex` is not necessary when adding a component - it's built into the build process.

Requires https://github.com/matrix-org/matrix-react-sdk/pull/863