### PR TITLE
Re-add productName

### DIFF
--- a/electron/package.json
+++ b/electron/package.json
@@ -1,5 +1,6 @@
 {
   "name": "riot-web",
+  "productName": "Riot",
   "main": "src/electron-main.js",
   "version": "0.9.8",
   "description": "A feature-rich client for Matrix.org",


### PR DESCRIPTION
so that electron-builder packages it as Riot rather than riot-web