### PR TITLE
Network Dropdown - Remember queried remote servers in dropdown list

### DIFF
--- a/src/components/structures/RoomDirectory.js
+++ b/src/components/structures/RoomDirectory.js
@@ -50,6 +50,7 @@ module.exports = React.createClass({
     getInitialState: function() {
         return {
             publicRooms: [],
+            serverList: [],
             loading: true,
             protocolsLoading: true,
             instanceId: null,
@@ -143,6 +144,9 @@ module.exports = React.createClass({
             this.setState((s) => {
                 s.publicRooms.push(...data.chunk);
                 s.loading = false;
+                if (s.serverList.indexOf(my_server) === -1) {
+                    s.serverList.push(my_server);
+                }
                 return s;
             });
             return Boolean(data.next_batch);
@@ -556,7 +560,11 @@ module.exports = React.createClass({
                             onChange={this.onFilterChange} onClear={this.onFilterClear} onJoinClick={this.onJoinClick}
                             placeholder={placeholder} showJoinButton={showJoinButton}
                         />
-                        <NetworkDropdown config={this.props.config} protocols={this.protocols} onOptionChange={this.onOptionChange} />
+                        <NetworkDropdown
+                            config={this.props.config}
+                            protocols={this.protocols}
+                            serverList={this.state.serverList}
+                            onOptionChange={this.onOptionChange} />
                     </div>
                     {content}
                 </div>

--- a/src/components/views/directory/NetworkDropdown.js
+++ b/src/components/views/directory/NetworkDropdown.js
@@ -131,8 +131,8 @@ export default class NetworkDropdown extends React.Component {
         const options = [];
 
         let servers = [];
-        if (this.props.config.servers) {
-            servers = servers.concat(this.props.config.servers);
+        if (this.props.serverList) {
+            servers = servers.concat(this.props.serverList);
         }
 
         if (servers.indexOf(MatrixClientPeg.getHomeServerName()) == -1) {
@@ -230,11 +230,12 @@ export default class NetworkDropdown extends React.Component {
 NetworkDropdown.propTypes = {
     onOptionChange: React.PropTypes.func.isRequired,
     protocols: React.PropTypes.object,
-    // The room directory config. May have a 'servers' key that is a list of server names to include in the dropdown
+    serverList: React.PropTypes.array,
     config: React.PropTypes.object,
 };
 
 NetworkDropdown.defaultProps = {
+    serverList: [],
     protocols: {},
     config: {},
 };


### PR DESCRIPTION
Addresses #3770. If a remote-server was queried and a valid (non-error) response was returned, add it to the serverList in the Network Dropdown. 