### PR TITLE
Desktop: 'copy link address'

### DIFF
--- a/electron_app/src/electron-main.js
+++ b/electron_app/src/electron-main.js
@@ -86,6 +86,12 @@ function onLinkContextMenu(ev, params) {
             safeOpenURL(params.linkURL);
         },
     }));
+    popup_menu.append(new electron.MenuItem({
+        label: 'Copy Link Address',
+        click() {
+            electron.clipboard.writeText(params.linkURL);
+        },
+    }));
     popup_menu.popup();
     ev.preventDefault();
 }


### PR DESCRIPTION
Add 'copy link address' to link context menu in electron app

Fixes https://github.com/vector-im/riot-web/issues/2712