### PR TITLE
Fix some setState-after-unmount in roomdirectory

### DIFF
--- a/src/components/structures/RoomDirectory.js
+++ b/src/components/structures/RoomDirectory.js
@@ -60,6 +60,7 @@ module.exports = React.createClass({
     },
 
     componentWillMount: function() {
+        this._unmounted = false;
         this.nextBatch = null;
         this.filterTimeout = null;
         this.scrollPanel = null;
@@ -97,6 +98,10 @@ module.exports = React.createClass({
         //     sideOpacity: 1.0,
         //     middleOpacity: 1.0,
         // });
+        if (this.filterTimeout) {
+            clearTimeout(this.filterTimeout);
+        }
+        this._unmounted = true;
     },
 
     refreshRoomList: function() {
@@ -139,6 +144,11 @@ module.exports = React.createClass({
                 return;
             }
 
+            if (this._unmounted) {
+                // if we've been unmounted, we don't care either.
+                return;
+            }
+
             this.nextBatch = data.next_batch;
             this.setState((s) => {
                 s.publicRooms.push(...data.chunk);
@@ -156,6 +166,12 @@ module.exports = React.createClass({
                 // requests either
                 return;
             }
+
+            if (this._unmounted) {
+                // if we've been unmounted, we don't care either.
+                return;
+            }
+
             this.setState({ loading: false });
             console.error("Failed to get publicRooms: %s", JSON.stringify(err));
             var ErrorDialog = sdk.getComponent("dialogs.ErrorDialog");


### PR DESCRIPTION
Give the RoomDirectory and unmounted guard, and use it to avoid some setState
warnings. Also, cancel the filterTimeout (no point in leaving it around).

There are still plenty of other opportunities to setState after unmount, but
the filterTimeout was causing noise in the test.