### PR TITLE
Add `Chat` to Linux app categories

### DIFF
--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     ],
     "linux": {
       "target": "deb",
-      "category": "Network;InstantMessaging;",
+      "category": "Network;InstantMessaging;Chat",
       "maintainer": "support@riot.im",
       "desktop": {
         "StartupWMClass": "riot-web"


### PR DESCRIPTION
most dists of riot-web inc Arch have these cats + Chat and IRCClient,
though the latter isn't exactly correct so missing it

builds on comments from #3975