### PR TITLE
Fixed an input field's background color in dark theme

### DIFF
--- a/src/skins/vector/css/matrix-react-sdk/views/dialogs/_ConfirmUserActionDialog.scss
+++ b/src/skins/vector/css/matrix-react-sdk/views/dialogs/_ConfirmUserActionDialog.scss
@@ -37,6 +37,7 @@ limitations under the License.
     font-family: 'Open Sans', Arial, Helvetica, Sans-Serif;
     font-size: 14px;
     color: $primary-fg-color;
+    background-color: $primary-bg-color;
 
     border-radius: 3px;
     border: solid 1px $input-border-color;


### PR DESCRIPTION
#3927 

Changed it to look like this:
![screenshot_2017-05-27_15-14-29](https://cloud.githubusercontent.com/assets/3164917/26522042/b661473a-42ef-11e7-836f-56f0cc03d2a9.png)

This is consistent with the "Create new room" dialog, which also has a dark text input box. I noticed their font sizes are slightly different (14px vs 15px), should this be the case?