### PR TITLE
Smaller font size on timestamp to better fit in the available space

### DIFF
--- a/src/skins/vector/css/matrix-react-sdk/views/rooms/_EventTile.scss
+++ b/src/skins/vector/css/matrix-react-sdk/views/rooms/_EventTile.scss
@@ -62,7 +62,7 @@ limitations under the License.
     visibility: hidden;
     white-space: nowrap;
     color: $event-timestamp-color;
-    font-size: 11px;
+    font-size: 10px;
     left: 8px;
     position: absolute;
 }


### PR DESCRIPTION
Part of addressing vector-im/riot-web#4046

Partner PR: https://github.com/matrix-org/matrix-react-sdk/pull/969

See: https://github.com/vector-im/riot-web/issues/4046#issuecomment-304909444