### PR TITLE
Various tweaks to fetch-develop-deps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,6 @@ node_js:
     - 6
     - 7
 install:
-    - scripts/fetch-develop.deps.sh
-    - npm install
+    # clone the deps with depth 1: we know we will only ever need that one
+    # commit.
+    - scripts/fetch-develop.deps.sh --depth 1 && npm install

--- a/scripts/fetch-develop.deps.sh
+++ b/scripts/fetch-develop.deps.sh
@@ -8,6 +8,8 @@
 
 set -e
 
+GIT_CLONE_ARGS=("$@")
+
 # Look in the many different CI env vars for which branch we're
 # building
 if [[ "$TRAVIS" == true ]]; then
@@ -25,41 +27,62 @@ fi
 
 echo "Determined branch to be $curbranch"
 
+# clone a specific branch of a github repo
+function clone() {
+    org=$1
+    repo=$2
+    branch=$3
+    git clone https://github.com/$org/$repo.git $repo --branch $branch \
+        "${GIT_CLONE_ARGS[@]}"
+}
+
 function dodep() {
     org=$1
     repo=$2
-    rm -rf $repo || true
-    git clone https://github.com/$org/$repo.git $repo
-    pushd $repo
-    git checkout $curbranch || git checkout develop
-    echo "$repo set to branch "`git rev-parse --abbrev-ref HEAD`
-    popd
+    rm -rf $repo
+    clone $org $repo $curbranch || {
+        [ "$curbranch" != 'develop' ] && clone $org $repo develop
+    } || return $?
+
+    (
+        cd $repo
+        echo "$repo set to branch "`git rev-parse --abbrev-ref HEAD`
+    )
+
+    mkdir -p node_modules
+    rm -r "node_modules/$repo" 2>/dev/null || true
+    ln -sv "../$repo" node_modules/
 }
 
+echo -en 'travis_fold:start:matrix-js-sdk\r'
+echo 'Setting up matrix-js-sdk'
+
 dodep matrix-org matrix-js-sdk
+(
+    cd node_modules/matrix-js-sdk
+    npm install
+)
+
+echo -en 'travis_fold:end:matrix-js-sdk\r'
+
+echo -en 'travis_fold:start:matrix-react-sdk\r'
+echo 'Setting up matrix-react-sdk'
+
 dodep matrix-org matrix-react-sdk
 
-mkdir -p node_modules
-cd node_modules
+mkdir -p node_modules/matrix-react-sdk/node_modules
+ln -s ../../matrix-js-sdk node_modules/matrix-react-sdk/node_modules/
 
-rm -r matrix-js-sdk 2> /dev/null || true
-ln -s ../matrix-js-sdk ./
-pushd matrix-js-sdk
-npm install
-popd
+(
+    cd node_modules/matrix-react-sdk
+    npm install
+)
 
-rm -r matrix-react-sdk 2> /dev/null || true
-ln -s ../matrix-react-sdk ./
-pushd matrix-react-sdk
-mkdir -p node_modules
-cd node_modules
-ln -s ../../matrix-js-sdk matrix-js-sdk
-cd ..
-npm install
-popd
+echo -en 'travis_fold:end:matrix-react-sdk\r'
+
 # Link the reskindex binary in place: if we used npm link,
 # npm would do this for us, but we don't because we'd have
 # to define the npm prefix somewhere so it could put the
 # intermediate symlinks there. Instead, we do it ourselves.
-mkdir -p .bin
-ln -sf ../matrix-react-sdk/scripts/reskindex.js .bin/reskindex
+mkdir -p node_modules/.bin
+ln -sfv ../matrix-react-sdk/scripts/reskindex.js node_modules/.bin/reskindex


### PR DESCRIPTION
* tell git to checkout the right branch, rather than cloning and then changing.
* clone with depth 1 under travis, to save time.
* less pushd/popd, which print out confusing text - use `cd` in a subshell
  instead. (and just avoid it where possible).
* add some markers to the output to let travis roll it up.