### PR TITLE
to make the windows volume mixer not explode as it can't resize icons.

### DIFF
--- a/electron_app/package.json
+++ b/electron_app/package.json
@@ -6,8 +6,9 @@
   "description": "A feature-rich client for Matrix.org",
   "author": "Vector Creations Ltd.",
   "dependencies": {
-    "electron-window-state": "^4.1.0",
     "auto-launch": "^5.0.1",
-    "minimist": "^1.2.0"
+    "electron-window-state": "^4.1.0",
+    "minimist": "^1.2.0",
+    "png-to-ico": "^1.0.2"
   }
 }

--- a/electron_app/src/tray.js
+++ b/electron_app/src/tray.js
@@ -16,6 +16,9 @@ limitations under the License.
 */
 
 const {app, Tray, Menu, nativeImage} = require('electron');
+const pngToIco = require('png-to-ico');
+const path = require('path');
+const fs = require('fs');
 
 let trayIcon = null;
 
@@ -57,7 +60,7 @@ exports.create = function(win, config) {
     trayIcon.on('click', toggleWin);
 
     let lastFavicon = null;
-    win.webContents.on('page-favicon-updated', function(ev, favicons) {
+    win.webContents.on('page-favicon-updated', async function(ev, favicons) {
         let newFavicon = config.icon_path;
         if (favicons && favicons.length > 0 && favicons[0].startsWith('data:')) {
             newFavicon = favicons[0];
@@ -70,19 +73,19 @@ exports.create = function(win, config) {
         // if its not default we have to construct into nativeImage
         if (newFavicon !== config.icon_path) {
             newFavicon = nativeImage.createFromDataURL(favicons[0]);
-            trayIcon.setImage(newFavicon);
 
             if (process.platform === 'win32') {
-                newFavicon = newFavicon.resize({
-                    height: 40,
-                    width: 40,
-                });
+                try {
+                    const icoPath = path.join(app.getPath('temp'), 'win32_riot_icon.ico')
+                    const icoBuf = await pngToIco(newFavicon.toPNG());
+                    fs.writeFileSync(icoPath, icoBuf);
+                    newFavicon = icoPath;
+                } catch (e) {console.error(e);}
             }
-            win.setIcon(newFavicon);
-        } else {
-            trayIcon.setImage(newFavicon);
-            win.setIcon(newFavicon);
         }
+
+        trayIcon.setImage(newFavicon);
+        win.setIcon(newFavicon);
     });
 
     win.webContents.on('page-title-updated', function(ev, title) {

--- a/electron_app/src/tray.js
+++ b/electron_app/src/tray.js
@@ -70,10 +70,19 @@ exports.create = function(win, config) {
         // if its not default we have to construct into nativeImage
         if (newFavicon !== config.icon_path) {
             newFavicon = nativeImage.createFromDataURL(favicons[0]);
-        }
+            trayIcon.setImage(newFavicon);
 
-        trayIcon.setImage(newFavicon);
-        win.setIcon(newFavicon);
+            if (process.platform === 'win32') {
+                newFavicon = newFavicon.resize({
+                    height: 40,
+                    width: 40,
+                });
+            }
+            win.setIcon(newFavicon);
+        } else {
+            trayIcon.setImage(newFavicon);
+            win.setIcon(newFavicon);
+        }
     });
 
     win.webContents.on('page-title-updated', function(ev, title) {


### PR DESCRIPTION
fixes 
![image](https://cloud.githubusercontent.com/assets/2403652/26760613/81cb4332-4915-11e7-882a-c9503e3b87c1.png)

Might not be the best way, probably worth @dbkr looking it over.

I hate Windows.

Signed-off-by: Michael Telatynski <7t3chguy@gmail.com>