### PR TITLE
Fix #4191: add defaults to avoid throwing

### DIFF
--- a/src/vector/platform/WebPlatform.js
+++ b/src/vector/platform/WebPlatform.js
@@ -160,8 +160,8 @@ export default class WebPlatform extends VectorBasePlatform {
         const appName = u.format();
 
         const ua = new UAParser();
-        const browserName = ua.getBrowser().name;
-        const osName = ua.getOS().name;
+        const browserName = ua.getBrowser().name || "unknown browser";
+        const osName = ua.getOS().name || "unknown os";
         return _t('%(appName)s via %(browserName)s on %(osName)s', {appName: appName, browserName: browserName, osName: osName});
     }
 


### PR DESCRIPTION
This is utterly frustrating. ES6 template strings support `undefined` values fine:
```js
> s = {}
{}
> console.log(`hello ${s.world}`)
hello undefined
```

Yet our translation library `counterpart` does not support this (specifically one of its deps, `sprintf` doesn't), and instead unceremoniously crashes the app: https://github.com/alexei/sprintf.js/blob/bfeab902cbf32d570409676da2624dfa8788c43a/src/sprintf.js#L45

Meaning when I added i18n support for this and converted from ES6 template strings to `_t()`, it could crash if any of these values were `undefined`. I'm going to have to check all existing `%(value)s` for null guards or patch `sprintf` to not suck.