### PR TITLE
Fix tests for new-guest-access

### DIFF
--- a/src/components/structures/HomePage.js
+++ b/src/components/structures/HomePage.js
@@ -62,7 +62,7 @@ module.exports = React.createClass({
                 { method: "GET", url: src },
                 (err, response, body) => {
                     if (err || response.status < 200 || response.status >= 300) {
-                        console.log(error);
+                        console.log(err);
                         this.setState({ page: "Couldn't load home page" });
                     }
 

--- a/test/app-tests/joining.js
+++ b/test/app-tests/joining.js
@@ -88,12 +88,12 @@ describe('joining a room', function () {
             var mc = (
                 <MatrixChat config={{}}
                     makeRegistrationUrl={()=>{throw new Error("unimplemented");}}
+                    initialScreenAfterLogin={{
+                        screen: 'directory',
+                    }}
                 />
             );
             matrixChat = ReactDOM.render(mc, parentDiv);
-
-            // switch to the Directory
-            matrixChat._setPage(PageTypes.RoomDirectory);
 
             var roomView;
 
@@ -138,7 +138,11 @@ describe('joining a room', function () {
                 httpBackend.when('GET', '/directory/room/'+encodeURIComponent(ROOM_ALIAS)).respond(200, { room_id: ROOM_ID });
                 httpBackend.when('GET', '/rooms/'+encodeURIComponent(ROOM_ID)+"/initialSync")
                     .respond(401, {errcode: 'M_GUEST_ACCESS_FORBIDDEN'});
-                return httpBackend.flush();
+
+                return q.all([
+                    httpBackend.flush('/directory/room/'+encodeURIComponent(ROOM_ALIAS)),
+                    httpBackend.flush('/rooms/'+encodeURIComponent(ROOM_ID)+"/initialSync"),
+                ]);
             }).then(() => {
                 httpBackend.verifyNoOutstandingExpectation();
 
@@ -146,30 +150,20 @@ describe('joining a room', function () {
                 roomView = ReactTestUtils.findRenderedComponentWithType(
                     matrixChat, RoomView);
 
-                var previewBar = ReactTestUtils.findRenderedComponentWithType(
+                const previewBar = ReactTestUtils.findRenderedComponentWithType(
                     roomView, RoomPreviewBar);
 
-                var joinLink = ReactTestUtils.findRenderedDOMComponentWithTag(
+                const joinLink = ReactTestUtils.findRenderedDOMComponentWithTag(
                     previewBar, 'a');
 
                 ReactTestUtils.Simulate.click(joinLink);
 
-                // that will fire off a request to check our displayname, followed by a
-                // join request
-                httpBackend.when('GET', '/profile/'+encodeURIComponent(USER_ID))
-                    .respond(200, {displayname: 'boris'});
-                httpBackend.when('POST', '/join/'+encodeURIComponent(ROOM_ALIAS))
+                httpBackend.when('POST', '/join/'+encodeURIComponent(ROOM_ID))
                     .respond(200, {room_id: ROOM_ID});
-                return httpBackend.flush();
             }).then(() => {
                 // wait for the join request to be made
                 return q.delay(1);
             }).then(() => {
-                // flush it through
-                return httpBackend.flush();
-            }).then(() => {
-                httpBackend.verifyNoOutstandingExpectation();
-
                 // the roomview should now be loading
                 expect(roomView.state.room).toBe(null);
                 expect(roomView.state.joining).toBe(true);
@@ -177,6 +171,14 @@ describe('joining a room', function () {
                 // there should be a spinner
                 ReactTestUtils.findRenderedDOMComponentWithClass(
                     roomView, "mx_Spinner");
+
+                // flush it through
+                return httpBackend.flush('/join/'+encodeURIComponent(ROOM_ID));
+            }).then(() => {
+                httpBackend.verifyNoOutstandingExpectation();
+
+                // We've joined, expect this to false
+                expect(roomView.state.joining).toBe(false);
 
                 // now send the room down the /sync pipe
                 httpBackend.when('GET', '/sync').
@@ -197,7 +199,6 @@ describe('joining a room', function () {
             }).then(() => {
                 // now the room should have loaded
                 expect(roomView.state.room).toExist();
-                expect(roomView.state.joining).toBe(false);
             }).done(done, done);
         });
     });

--- a/test/app-tests/loading.js
+++ b/test/app-tests/loading.js
@@ -122,7 +122,7 @@ describe('loading:', function () {
         function routeUrl(location, matrixChat) {
             console.log(Date.now() + ` routing URL '${location}'`);
             const s = getScreenFromLocation(location);
-            console.log("Showing screen "+ s);
+            console.log("Showing screen ", s);
             matrixChat.showScreen(s.screen, s.params);
         }
 
@@ -193,14 +193,12 @@ describe('loading:', function () {
 
                 return httpBackend.flush();
             }).then(() => {
-                // Wait for another trip around the event loop for the UI to update
-                return q.delay(1);
-            }).then(() => {
-                // we expect a single <Login> component
+                // we expect a single <Login> component following session load
                 ReactTestUtils.findRenderedComponentWithType(
                     matrixChat, sdk.getComponent('structures.login.Login'));
                 expect(windowLocation.hash).toEqual("");
-            }).done(done, done);
+                done();
+            });
         });
 
         it('should follow the original link after successful login', function(done) {


### PR DESCRIPTION
This time the test wasn't being flaky, but it does inspect a lot of the internal of RoomView, which has had some modifications recently. I've updated the test to reflect this and it passes locally.

Also, fix a bug in HomePage with an undeclared "error" which should be "err".

Let's see what Travis thinks of this!.... Oh wait, there isn't a luke/fix-tests branch on react-sdk? ...