### PR TITLE
Remove Tray Icon on exit

### DIFF
--- a/electron_app/src/electron-main.js
+++ b/electron_app/src/electron-main.js
@@ -288,6 +288,8 @@ electron.app.on('ready', () => {
             return false;
         }
     });
+    
+    tray.destroy();
 
     webContentsHandler(mainWindow.webContents);
     mainWindowState.manage(mainWindow);


### PR DESCRIPTION
Leaving the tray Icon behind is doing a bad looking stack of Riot logos in windows. To fix this stacking issue just destroy it on exit.