### PR TITLE
Add border on hover for code blocks

### DIFF
--- a/src/skins/vector/css/matrix-react-sdk/views/rooms/_EventTile.scss
+++ b/src/skins/vector/css/matrix-react-sdk/views/rooms/_EventTile.scss
@@ -345,7 +345,7 @@ limitations under the License.
 }
 .mx_EventTile_body pre {
     position: relative;
-    border: 1px solid #f8f8f8;
+    border: 1px solid transparent;
 }
 .mx_EventTile:hover .mx_EventTile_body pre
 {

--- a/src/skins/vector/css/matrix-react-sdk/views/rooms/_EventTile.scss
+++ b/src/skins/vector/css/matrix-react-sdk/views/rooms/_EventTile.scss
@@ -345,6 +345,11 @@ limitations under the License.
 }
 .mx_EventTile_body pre {
     position: relative;
+    border: 1px solid #f8f8f8;
+}
+.mx_EventTile:hover .mx_EventTile_body pre
+{
+    border: 1px solid $primary-hairline-color;
 }
 .mx_EventTile_body pre:hover .mx_EventTile_copyButton
 {


### PR DESCRIPTION
The border for non hovered codeblocks is the same colour as the background, and there so the content doesn't move when the border is added.