### PR TITLE
Update import and directory path in the Translations dev guide

### DIFF
--- a/docs/translating-dev.md
+++ b/docs/translating-dev.md
@@ -8,9 +8,9 @@
 
 ## Adding new strings
 
-1. Check if the import ``import _t from 'counterpart-riot'`` is present. If not add it to the other import statements.
+1. Check if the import ``import { _t } from 'matrix-react-sdk/lib/languageHandler';`` is present. If not add it to the other import statements.
 2. Add ``_t()`` to your string. (Don't forget curly braces when you assign an expression to JSX attributes in the render method)
-3. Add the String to the ``en_EN.json`` file in ``src/i18n`` or if you are working in matrix-react-sdk you can find the json file in ``src/i18n/strings``
+3. Add the String to the ``en_EN.json`` file in ``src/i18n/strings`` (respect which repository you are on).
 
 ## Adding variables inside a string.
 


### PR DESCRIPTION
Path to the  en_EN.json and the import were outdated.

