### PR TITLE
Tweak tests to match updates to matrixchat

### DIFF
--- a/src/vector/index.js
+++ b/src/vector/index.js
@@ -216,18 +216,16 @@ function getConfig() {
     return deferred.promise;
 }
 
-function onLoadCompleted() {
+function onTokenLoginCompleted() {
     // if we did a token login, we're now left with the token, hs and is
     // url as query params in the url; a little nasty but let's redirect to
     // clear them.
-    if (window.location.search) {
-        var parsedUrl = url.parse(window.location.href);
-        parsedUrl.search = "";
-        var formatted = url.format(parsedUrl);
-        console.log("Redirecting to " + formatted + " to drop loginToken " +
-                    "from queryparams");
-        window.location.href = formatted;
-    }
+    var parsedUrl = url.parse(window.location.href);
+    parsedUrl.search = "";
+    var formatted = url.format(parsedUrl);
+    console.log("Redirecting to " + formatted + " to drop loginToken " +
+                "from queryparams");
+    window.location.href = formatted;
 }
 
 async function loadApp() {
@@ -288,7 +286,7 @@ async function loadApp() {
                 realQueryParams={params}
                 startingFragmentQueryParams={fragparts.params}
                 enableGuest={true}
-                onLoadCompleted={onLoadCompleted}
+                onTokenLoginCompleted={onTokenLoginCompleted}
                 initialScreenAfterLogin={getScreenFromLocation(window.location)}
                 defaultDeviceDisplayName={PlatformPeg.get().getDefaultDeviceDisplayName()}
             />,


### PR DESCRIPTION
Update the vector-web tests to handle the refactorathon that happened in https://github.com/matrix-org/matrix-react-sdk/pull/1102.

Mostly this is just making it look at the `view` state rather than the individual boolean flags.

One other tweak merits explanation: we now implement the initial couldn't-register-as-guest login with an explicit switch to the LOGIN view, which means that the URL gets updated to #/login.