### PR TITLE
Fix npm@5 bug when doing npm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "lint": "eslint src/",
     "lintall": "eslint src/ test/",
     "clean": "rimraf lib webapp electron_app/dist",
-    "prepublish": "npm run build:compile",
+    "prepare": "npm run build:compile",
     "test": "karma start --single-run=true --autoWatch=false --browsers PhantomJS --colors=false",
     "test-multi": "karma start"
   },


### PR DESCRIPTION
NPM@5.x droped support of prepublish for npm install. prepare replaces prepublish. See https://github.com/npm/npm/issues/10074