### PR TITLE
Fix h2 in markdown being weird

### DIFF
--- a/src/components/views/messages/DateSeparator.js
+++ b/src/components/views/messages/DateSeparator.js
@@ -53,7 +53,7 @@ module.exports = React.createClass({
         }
 
         return (
-            <h2>{ label }</h2>
+            <h2 className="mx_DateSeparator">{ label }</h2>
         );
     }
 });

--- a/src/skins/vector/css/_components.scss
+++ b/src/skins/vector/css/_components.scss
@@ -77,6 +77,7 @@
 @import "./vector-web/views/elements/_ImageView.scss";
 @import "./vector-web/views/elements/_Spinner.scss";
 @import "./vector-web/views/globals/_MatrixToolbar.scss";
+@import "./vector-web/views/messages/_DateSeparator.scss";
 @import "./vector-web/views/messages/_MessageTimestamp.scss";
 @import "./vector-web/views/messages/_SenderProfile.scss";
 @import "./vector-web/views/rooms/_RoomDropTarget.scss";

--- a/src/skins/vector/css/matrix-react-sdk/structures/_RoomView.scss
+++ b/src/skins/vector/css/matrix-react-sdk/structures/_RoomView.scss
@@ -127,15 +127,6 @@ limitations under the License.
     clear: both;
 }
 
-.mx_RoomView_MessageList h2 {
-    clear: both;
-    margin-top: 32px;
-    margin-bottom: 8px;
-    margin-left: 63px;
-    padding-bottom: 6px;
-    border-bottom: 1px solid $primary-hairline-color;
-}
-
 .mx_RoomView_invitePrompt {
     order: 2;
 

--- a/src/skins/vector/css/vector-web/views/messages/_DateSeparator.scss
+++ b/src/skins/vector/css/vector-web/views/messages/_DateSeparator.scss
@@ -1,0 +1,25 @@
+/*
+Copyright 2017 Vector Creations Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+.mx_DateSeparator {
+    clear: both;
+    margin-top: 32px;
+    margin-bottom: 8px;
+    margin-left: 63px;
+    padding-bottom: 6px;
+    border-bottom: 1px solid $primary-hairline-color;
+}
+


### PR DESCRIPTION
Date separator style was just define don any h2 in the message
list, so got picked up by any h2s in markdown too. Give date
separators their own class.

Fixes https://github.com/vector-im/riot-web/issues/4328