### PR TITLE
Set uid/gid to 0 in tarball

### DIFF
--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -30,7 +30,7 @@ else
     echo ${version} > riot-$version/version
 fi
 
-tar chvzf dist/riot-$version.tar.gz riot-$version
+tar chvz --owner=0 --group=0 -f dist/riot-$version.tar.gz riot-$version
 rm -r riot-$version
 
 echo


### PR DESCRIPTION
Give the files in thar tarball user and group root, so that when you untar it
you don't get a surprise if you happen to have a user named the same as the
build user.

@dbkr: can you check this works on your fruit-flavoured OS?