### PR TITLE
do not give transparent avatars a white background

### DIFF
--- a/src/skins/vector/css/matrix-react-sdk/views/avatars/_BaseAvatar.scss
+++ b/src/skins/vector/css/matrix-react-sdk/views/avatars/_BaseAvatar.scss
@@ -30,5 +30,4 @@ limitations under the License.
 .mx_BaseAvatar_image {
     border-radius: 40px;
     vertical-align: top;
-    background-color: #fff;
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2158203/27519586-538e6b32-59f7-11e7-8de6-ffc342594e3d.png)

All avatars within riot have a white background. Normally this is not visible, as most avatars are opaque. However, if someone chooses to add some transparency to their avatar image, the white background shines through.

This PR simple removes the background, making those avatars look as they should.