### PR TITLE
fix Quote not closing contextual menu

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,4 @@ node_js:
 install:
     # clone the deps with depth 1: we know we will only ever need that one
     # commit.
-    - scripts/fetch-develop.deps.sh --depth 1 && npm install
+    - scripts/fetch-develop.deps.sh --depth 1 && npm i phantomjs-prebuilt && npm install

--- a/src/components/views/context_menus/MessageContextMenu.js
+++ b/src/components/views/context_menus/MessageContextMenu.js
@@ -67,7 +67,7 @@ module.exports = React.createClass({
 
     onResendClick: function() {
         Resend.resend(this.props.mxEvent);
-        if (this.props.onFinished) this.props.onFinished();
+        this.closeMenu();
     },
 
     onViewSourceClick: function() {
@@ -75,7 +75,7 @@ module.exports = React.createClass({
         Modal.createDialog(ViewSource, {
             content: this.props.mxEvent.event,
         }, 'mx_Dialog_viewsource');
-        if (this.props.onFinished) this.props.onFinished();
+        this.closeMenu();
     },
 
     onViewClearSourceClick: function() {
@@ -84,7 +84,7 @@ module.exports = React.createClass({
             // FIXME: _clearEvent is private
             content: this.props.mxEvent._clearEvent,
         }, 'mx_Dialog_viewsource');
-        if (this.props.onFinished) this.props.onFinished();
+        this.closeMenu();
     },
 
     onRedactClick: function() {
@@ -106,12 +106,12 @@ module.exports = React.createClass({
                 }).done();
             },
         }, 'mx_Dialog_confirmredact');
-        if (this.props.onFinished) this.props.onFinished();
+        this.closeMenu();
     },
 
     onCancelSendClick: function() {
         Resend.removeFromQueue(this.props.mxEvent);
-        if (this.props.onFinished) this.props.onFinished();
+        this.closeMenu();
     },
 
     onForwardClick: function() {
@@ -130,7 +130,7 @@ module.exports = React.createClass({
         if (this.props.eventTileOps) {
             this.props.eventTileOps.unhideWidget();
         }
-        if (this.props.onFinished) this.props.onFinished();
+        this.closeMenu();
     },
 
     onQuoteClick: function() {
@@ -139,6 +139,7 @@ module.exports = React.createClass({
             action: 'quote',
             event: this.props.mxEvent,
         });
+        this.closeMenu();
     },
 
     render: function() {


### PR DESCRIPTION
also use `this.closeMenu();` over the explicit direct call as the wrapper exists and is a little clearer

fixes 
![image](https://user-images.githubusercontent.com/2403652/27590918-178bb0ac-5b48-11e7-8232-fe9111449f88.png)
