### PR TITLE
Fix long words causing MessageComposer to widen

### DIFF
--- a/src/skins/vector/css/matrix-react-sdk/views/rooms/_MessageComposer.scss
+++ b/src/skins/vector/css/matrix-react-sdk/views/rooms/_MessageComposer.scss
@@ -87,6 +87,7 @@ limitations under the License.
     flex: 1;
     max-height: 120px;
     overflow: auto;
+    word-break: break-word;
 }
 
 .mx_MessageComposer_input blockquote {


### PR DESCRIPTION
Use `word-break: break-word` to split long words.

Fixes https://github.com/vector-im/riot-web/issues/4414