### PR TITLE
Apply white-space: pre-wrap to mx_MEmoteBody

### DIFF
--- a/src/skins/vector/css/matrix-react-sdk/views/messages/_MEmoteBody.scss
+++ b/src/skins/vector/css/matrix-react-sdk/views/messages/_MEmoteBody.scss
@@ -14,6 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+.mx_MEmoteBody {
+    white-space: pre-wrap;
+}
+
 .mx_MEmoteBody_sender {
     cursor: pointer;
 }


### PR DESCRIPTION
as we do with MTextBody.

So that people can do multi-line emotes...