### PR TITLE
Truncate auto-complete pills properly

### DIFF
--- a/src/skins/vector/css/matrix-react-sdk/views/rooms/_Autocomplete.scss
+++ b/src/skins/vector/css/matrix-react-sdk/views/rooms/_Autocomplete.scss
@@ -50,14 +50,16 @@
     margin: 0 3px;
 }
 
-.mx_Autocomplete_Completion_title,
-.mx_Autocomplete_Completion_subtitle,
-.mx_Autocomplete_Completion_description {
-    /* Ellipsis for long names/subtitles/descriptions*/
-    max-width: 150px;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
+.mx_Autocomplete_Completion_container_truncate {
+    .mx_Autocomplete_Completion_title,
+    .mx_Autocomplete_Completion_subtitle,
+    .mx_Autocomplete_Completion_description {
+        /* Ellipsis for long names/subtitles/descriptions*/
+        max-width: 150px;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
 }
 
 /* container for pill-style completions */

--- a/src/skins/vector/css/matrix-react-sdk/views/rooms/_Autocomplete.scss
+++ b/src/skins/vector/css/matrix-react-sdk/views/rooms/_Autocomplete.scss
@@ -50,7 +50,6 @@
     margin: 0 3px;
 }
 
-.mx_Autocomplete_provider_name,
 .mx_Autocomplete_Completion_title,
 .mx_Autocomplete_Completion_subtitle,
 .mx_Autocomplete_Completion_description {


### PR DESCRIPTION
 - Don't auto-complete the names (section headings) of auto-completions
 - Only truncate if the pills are within a certain class of element

Required for https://github.com/matrix-org/matrix-react-sdk/pull/1178