### PR TITLE
Transform `async` functions to bluebird promises

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,4 @@
 {
   "presets": ["react", "es2015", "es2016"],
-  "plugins": ["transform-class-properties", "transform-object-rest-spread", "transform-async-to-generator", "transform-runtime", "add-module-exports"]
+  "plugins": ["transform-class-properties", "transform-object-rest-spread", "transform-async-to-bluebird", "transform-runtime", "add-module-exports"]
 }

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "babel-eslint": "^6.1.0",
     "babel-loader": "^6.2.5",
     "babel-plugin-add-module-exports": "^0.2.1",
-    "babel-plugin-transform-async-to-generator": "^6.16.0",
+    "babel-plugin-transform-async-to-bluebird": "^1.1.1",
     "babel-plugin-transform-class-properties": "^6.16.0",
     "babel-plugin-transform-object-rest-spread": "^6.16.0",
     "babel-plugin-transform-runtime": "^6.15.0",


### PR DESCRIPTION
It turns out that the assertion made in https://github.com/vector-im/riot-web/pull/4565 about `async` functions returning bluebird promises was only correct when babel used an inline version of the `asyncToGenerator` helper; in riot-web we are using `babel-transform-runtime` which means that we use a separate `babel-runtime/helpers/asyncToGenerator`, which returns a native (or core-js) Promise.

This meant that we were still in the situation where some methods returned native Promises, and some bluebird ones, which is exactly the situation I wanted to resolve by switching to bluebird in the first place: in short, unless/until we get rid of all code which assumes Promises have a `done` method etc, we need to make sure that everything returns a bluebird promise.

(Aside: there was debate over whether in the long term we should be trying to wean ourselves off bluebird promises by assuming all promises are native. The conclusion was that the complexity hit involved in doing so outweighed any benefit of a potential future migration away from bluebird).