### PR TITLE
Deflake the joining test

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "karma-junit-reporter": "^0.4.1",
     "karma-mocha": "^0.2.2",
     "karma-webpack": "^1.7.0",
-    "matrix-mock-request": "^1.1.0",
+    "matrix-mock-request": "^1.2.0",
     "matrix-react-test-utils": "^0.2.0",
     "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",

--- a/test/app-tests/joining.js
+++ b/test/app-tests/joining.js
@@ -103,7 +103,9 @@ describe('joining a room', function () {
             httpBackend.when('GET', '/sync')
                 .respond(200, {});
 
-            return httpBackend.flushAllExpected().then(() => {
+            return httpBackend.flushAllExpected({
+                timeout: 1000,
+            }).then(() => {
                 // wait for the directory requests
                 httpBackend.when('POST', '/publicRooms').respond(200, {chunk: []});
                 httpBackend.when('GET', '/thirdparty/protocols').respond(200, {});


### PR DESCRIPTION
Just give the client longer to get started (it seems to be taking a long time
to get started talking to indexeddb)