### PR TITLE
Use `catch` instead of `fail` to handle room tag error

### DIFF
--- a/src/components/views/rooms/DNDRoomTile.js
+++ b/src/components/views/rooms/DNDRoomTile.js
@@ -130,10 +130,7 @@ var roomTileSource = {
             if (newTag && newTag !== 'im.vector.fake.direct' &&
                 (item.targetList !== item.originalList || newOrder)
             ) {
-                //component.state.set({ spinner: component.state.spinner ? component.state.spinner++ : 1 });
-                MatrixClientPeg.get().setRoomTag(item.room.roomId, newTag, newOrder).finally(function() {
-                    //component.state.set({ spinner: component.state.spinner-- });
-                }).fail(function(err) {
+                MatrixClientPeg.get().setRoomTag(item.room.roomId, newTag, newOrder).catch(function(err) {
                     var ErrorDialog = sdk.getComponent("dialogs.ErrorDialog");
                     console.error("Failed to add tag " + newTag + " to room: " + err);
                     Modal.createDialog(ErrorDialog, {


### PR DESCRIPTION
Because bluebird doesn't support fail

Fixes https://github.com/vector-im/riot-web/issues/4642