### PR TITLE
Support multiple config.json symlinks in redeploy.py

### DIFF
--- a/scripts/deploy.py
+++ b/scripts/deploy.py
@@ -63,7 +63,8 @@ class Deployer:
         self.packages_path = "."
         self.bundles_path = None
         self.should_clean = False
-        self.config_location = None
+        # filename -> symlink path e.g 'config.localhost.json' => '../localhost/config.json'
+        self.config_locations = {}
         self.verify_signature = True
 
     def deploy(self, tarball, extract_path):
@@ -95,11 +96,12 @@ class Deployer:
 
         print ("Extracted into: %s" % extracted_dir)
 
-        if self.config_location:
-            create_relative_symlink(
-                target=self.config_location,
-                linkname=os.path.join(extracted_dir, 'config.json')
-            )
+        if self.config_locations:
+            for config_filename, config_loc in self.config_locations.iteritems():
+                create_relative_symlink(
+                    target=config_loc,
+                    linkname=os.path.join(extracted_dir, config_filename)
+                )
 
         if self.bundles_path:
             extracted_bundles = os.path.join(extracted_dir, 'bundles')
@@ -178,6 +180,8 @@ if __name__ == "__main__":
     deployer.packages_path = args.packages_dir
     deployer.bundles_path = args.bundles_dir
     deployer.should_clean = args.clean
-    deployer.config_location = args.config
+    deployer.config_locations = {
+        "config.json": args.config,
+    }
 
     deployer.deploy(args.tarball, args.extract_path)

--- a/scripts/redeploy.py
+++ b/scripts/redeploy.py
@@ -185,10 +185,13 @@ if __name__ == "__main__":
             to the /vector directory INSIDE the tarball."
         )
     )
+
+    # --config config.json=../../config.json --config config.localhost.json=./localhost.json
     parser.add_argument(
-        "--config", dest="config", help=(
-            "Write a symlink to config.json in the extracted tarball. \
-            To this location."
+        "--config", action="append", dest="configs",
+        type=lambda kv: kv.split("="), help=(
+            "A list of configs to symlink into the extracted tarball. \
+            For example, --config config.json=../config.json config2.json=../test/config.json"
         )
     )
     parser.add_argument(
@@ -212,7 +215,8 @@ if __name__ == "__main__":
     deployer = Deployer()
     deployer.bundles_path = args.bundles_dir
     deployer.should_clean = args.clean
-    deployer.config_location = args.config
+    deployer.config_locations = dict(args.configs) if args.configs else {}
+
 
     # we don't pgp-sign jenkins artifacts; instead we rely on HTTPS access to
     # the jenkins server (and the jenkins server not being compromised and/or
@@ -225,13 +229,13 @@ if __name__ == "__main__":
         deploy_tarball(args.tarball_uri, build_dir)
     else:
         print(
-            "Listening on port %s. Extracting to %s%s. Symlinking to %s. Jenkins URL: %s. Config location: %s" %
+            "Listening on port %s. Extracting to %s%s. Symlinking to %s. Jenkins URL: %s. Config locations: %s" %
             (args.port,
              arg_extract_path,
              " (clean after)" if deployer.should_clean else "",
              arg_symlink,
              arg_jenkins_url,
-             deployer.config_location,
+             deployer.config_locations,
             )
         )
         app.run(host="0.0.0.0", port=args.port, debug=True)

--- a/scripts/redeploy.py
+++ b/scripts/redeploy.py
@@ -186,10 +186,13 @@ if __name__ == "__main__":
         )
     )
 
+    def _raise(ex):
+        raise ex
+
     # --config config.json=../../config.json --config config.localhost.json=./localhost.json
     parser.add_argument(
         "--config", action="append", dest="configs",
-        type=lambda kv: kv.split("="), help=(
+        type=lambda kv: kv.split("=", 1) if "=" in kv else _raise(Exception("Missing =")), help=(
             "A list of configs to symlink into the extracted tarball. \
             For example, --config config.json=../config.json config2.json=../test/config.json"
         )


### PR DESCRIPTION
Riot will attempt to load `config.$domain.json` prior to `config.json` to allow for different configuration options depending on if you're hitting `riot.im/develop` or `scalar-staging.riot.im/develop`.

The redeploy script didn't know this. Changed the CLI options from looking like:
```
python redeploy.py --config ../../config.json
```
to looking like:
```
python redeploy.py --config config.json=../../config.json --config config.scalar-staging.riot.im.json=../../scalar-staging/config.json
```

Without this, every time /develop deploys a new version, the scalar-staging config JSON disappears from /develop (since it was never added back in to the untarballed files, unlike config.json).