### PR TITLE
Increase the timeout for clearing indexeddbs

### DIFF
--- a/test/app-tests/loading.js
+++ b/test/app-tests/loading.js
@@ -82,9 +82,14 @@ describe('loading:', function () {
         // unmounting should have cleared the MatrixClientPeg
         expect(MatrixClientPeg.get()).toBe(null);
 
+        // chrome seems to take *ages* to delete the indexeddbs.
+        this.timeout(10000);
+
         // clear the indexeddbs so we can start from a clean slate next time.
-        await test_utils.deleteIndexedDB('matrix-js-sdk:crypto');
-        await test_utils.deleteIndexedDB('matrix-js-sdk:riot-web-sync');
+        await Promise.all([
+            test_utils.deleteIndexedDB('matrix-js-sdk:crypto'),
+            test_utils.deleteIndexedDB('matrix-js-sdk:riot-web-sync'),
+        ]);
         console.log(`${Date.now()}: loading: afterEach complete`);
     });
 

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -34,7 +34,8 @@ export function deleteIndexedDB(dbName) {
             return;
         }
 
-        console.log(`${Date.now()}: Removing indexeddb instance: ${dbName}`);
+        const startTime = Date.now();
+        console.log(`${startTime}: Removing indexeddb instance: ${dbName}`);
         const req = window.indexedDB.deleteDatabase(dbName);
 
         req.onblocked = () => {
@@ -48,7 +49,8 @@ export function deleteIndexedDB(dbName) {
         };
 
         req.onsuccess = () => {
-            console.log(`${Date.now()}: Removed indexeddb instance: ${dbName}`);
+            const now = Date.now();
+            console.log(`${now}: Removed indexeddb instance: ${dbName} in ${now-startTime} ms`);
             resolve();
         };
     }).catch((e) => {


### PR DESCRIPTION
Chrome seems to take ages (like, 1500ms regularly) to clear out the indexeddbs,
and that's causing test timeouts. Bump the timeout to hack around it.

Also: clear both dbs in parallel (can't hurt, right?) and improve diagnostics
on the process.