### PR TITLE
tweak compact theme

### DIFF
--- a/src/skins/vector/css/matrix-react-sdk/views/elements/_MemberEventListSummary.scss
+++ b/src/skins/vector/css/matrix-react-sdk/views/elements/_MemberEventListSummary.scss
@@ -50,11 +50,22 @@ limitations under the License.
 }
 
 .mx_MatrixChat_useCompactLayout {
+    .mx_MemberEventListSummary {
+        font-size: 13px;
+        .mx_EventTile_line {
+            line-height: 20px;
+        }
+    }
+
     .mx_MemberEventListSummary_line {
         line-height: 22px;
     }
 
     .mx_MemberEventListSummary_toggle {
-        margin-top: 2px;
+        margin-top: 3px;
+    }
+
+    .mx_TextualEvent.mx_MemberEventListSummary_summary {
+        font-size: 13px;
     }
 }

--- a/src/skins/vector/css/matrix-react-sdk/views/rooms/_EventTile.scss
+++ b/src/skins/vector/css/matrix-react-sdk/views/rooms/_EventTile.scss
@@ -396,7 +396,15 @@ limitations under the License.
     }
 
     .mx_EventTile.mx_EventTile_info {
+        // same as the padding for non-compact .mx_EventTile.mx_EventTile_info
         padding-top: 0px;
+        font-size: 13px;
+        .mx_EventTile_line {
+            line-height: 20px;
+        }
+        .mx_EventTile_avatar {
+            top: 4px;
+        }
     }
 
     .mx_EventTile .mx_SenderProfile {
@@ -404,6 +412,7 @@ limitations under the License.
     }
 
     .mx_EventTile.mx_EventTile_emote {
+        // add a bit more space for emotes so that avatars don't collide
         padding-top: 8px;
         .mx_EventTile_avatar {
             top: 2px;
@@ -431,10 +440,6 @@ limitations under the License.
         top: 2px;
     }
 
-    .mx_EventTile.mx_EventTile_info .mx_EventTile_avatar {
-        top: 5px;
-    }
-
     .mx_EventTile_e2eIcon {
         top: 7px;
     }
@@ -448,12 +453,21 @@ limitations under the License.
     }
 
     .mx_EventTile_continuation .mx_EventTile_readAvatars,
-    .mx_EventTile_info .mx_EventTile_readAvatars,
     .mx_EventTile_emote .mx_EventTile_readAvatars {
         top: 5px;
     }
 
+    .mx_EventTile_info .mx_EventTile_readAvatars {
+        top: 4px;
+    }
+
     .mx_RoomView_MessageList h2 {
         margin-top: 6px;
+    }
+
+    .mx_EventTile_content .markdown-body {
+      p, ul, ol, dl, blockquote, pre, table {
+        margin-bottom: 4px; // 1/4 of the non-compact margin-bottom
+      }
     }
 }


### PR DESCRIPTION
- add some comments
- decrease size of info events and MELS (#4363.2)
- reduce spacing between paragraphs, lists, etc (#4363.3 & 4)

Assigning to @ara4n so that he can decide if he likes the changes or not. ;)  The reduced size of info event I think should be fine.  I'm not so sure about the reduced spacing between some elements, because, at least for paragraphs, it comes into effect or not depending on how the user entered the paragraphs (see discussion starting at https://github.com/vector-im/riot-web/issues/4363#issuecomment-310660402).