### PR TITLE
Make pills, emoji translucent when sending

### DIFF
--- a/src/skins/vector/css/matrix-react-sdk/views/rooms/_EventTile.scss
+++ b/src/skins/vector/css/matrix-react-sdk/views/rooms/_EventTile.scss
@@ -128,6 +128,12 @@ limitations under the License.
     color: $event-sending-color;
 }
 
+.mx_EventTile_sending .mx_UserPill,
+.mx_EventTile_sending .mx_RoomPill,
+.mx_EventTile_sending .mx_emojione {
+    opacity: 0.5;
+}
+
 .mx_EventTile_notSent {
     color: $event-notsent-color;
 }
@@ -370,6 +376,7 @@ limitations under the License.
 .mx_EventTile_content .markdown-body h6
 {
     font-family: inherit ! important;
+    color: inherit;
 }
 
 


### PR DESCRIPTION
also fix header colours, which now inherit the font colour of the event tile (so all headers have the correct colour when sending or when the event tile is highlighted for a mention)

fixes vector-im/riot-web#4656
fixes vector-im/riot-web#4421