### PR TITLE
update gitignore to allow .idea directory to exist in subdirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,6 @@
 npm-debug.log
 electron/dist
 electron/pub
-/.idea
+**/.idea
 /config.json
 /src/component-index.js


### PR DESCRIPTION
This gitignore update allows the .idea directory to exist in subdirectories. This is useful because it allows the for IntelliJ products to work in subdirectories without littering the git change-list. An example where this occurs is opening the electron-app directory in Webstorm.