### PR TITLE
Make member device info buttons fluid and stackable with flexbox

### DIFF
--- a/src/skins/vector/css/matrix-react-sdk/views/rooms/_MemberDeviceInfo.scss
+++ b/src/skins/vector/css/matrix-react-sdk/views/rooms/_MemberDeviceInfo.scss
@@ -18,6 +18,13 @@ limitations under the License.
     padding: 10px 0px;
 }
 
+.mx_MemberDeviceInfo.mx_DeviceVerifyButtons {
+    width: 100%;
+    padding: 6px 0;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+}
 
 .mx_MemberDeviceInfo_textButton {
     color: $accent-fg-color;
@@ -26,12 +33,11 @@ limitations under the License.
     text-align: center;
     padding-left: 1em;
     padding-right: 1em;
-    width: 95px;
     border: 0px;
     font-size: 14px;
-
     cursor: pointer;
-    display: inline;
+    margin: 2px;
+    flex: 1;
 }
 
 .mx_MemberDeviceInfo_deviceId {
@@ -42,11 +48,6 @@ limitations under the License.
     margin-bottom: 10px;
     padding-bottom: 10px;
     border-bottom: 1px solid rgba(0,0,0,0.1);
-}
-
-.mx_MemberDeviceInfo_blacklist,
-.mx_MemberDeviceInfo_unblacklist {
-    float: right;
 }
 
 /* "Unblacklist" is too long for a regular button: make it wider and

--- a/src/skins/vector/css/matrix-react-sdk/views/rooms/_MemberDeviceInfo.scss
+++ b/src/skins/vector/css/matrix-react-sdk/views/rooms/_MemberDeviceInfo.scss
@@ -19,7 +19,6 @@ limitations under the License.
 }
 
 .mx_MemberDeviceInfo.mx_DeviceVerifyButtons {
-    width: 100%;
     padding: 6px 0;
     display: flex;
     flex-wrap: wrap;


### PR DESCRIPTION
Buttons with short text stay as they are, buttons with long text don't get overflowed, but just grow and wrap on a new line if needed, still remaining aligned with others (helpful for translations that don't have short enough equivalent for button labels)

Screenshot (short English labels, longer Russian labels):
![Screenshot](https://i.imgur.com/7ZpZu8H.png)

It would be nice to get those into a device context menu eventually, the same as message actions are now under the message context menu.

Same as the #4703 but based on `develop` branch as @t3chguy and @lukebarnard1 suggested.

Signed-off-by: Andrei Shevchuk <andrei@shevchuk.co>