### PR TITLE
Fix overflowing login/register buttons on some languages issue #4804

### DIFF
--- a/src/components/structures/LoginBox.js
+++ b/src/components/structures/LoginBox.js
@@ -84,7 +84,7 @@ module.exports = React.createClass({
 
         var self = this;
         return (
-            <div className="mx_SearchBox">
+            <div className="mx_SearchBox mx_LoginBox">
                 { loginButton }
                 { toggleCollapse }
             </div>

--- a/src/skins/vector/css/matrix-react-sdk/structures/_LoginBox.scss
+++ b/src/skins/vector/css/matrix-react-sdk/structures/_LoginBox.scss
@@ -14,6 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+.mx_LoginBox {
+    min-height: 24px;
+    height: unset !important;
+    padding-top: 13px !important;
+    padding-bottom: 14px !important;
+}
+
 .mx_LoginBox_loginButton_wrapper {
     text-align: center;
     width: 100%;
@@ -21,13 +28,13 @@ limitations under the License.
 
 .mx_LoginBox_loginButton,
 .mx_LoginBox_registerButton {
-    margin-top: -8px;
+    margin-top: 3px;
     height: 40px;
     border: 0px;
     border-radius: 40px;
     margin-left: 4px;
     margin-right: 4px;
-    width: 80px;
+    min-width: 80px;
 
     background-color: $accent-color;
     color: $primary-bg-color;

--- a/src/skins/vector/css/matrix-react-sdk/structures/_LoginBox.scss
+++ b/src/skins/vector/css/matrix-react-sdk/structures/_LoginBox.scss
@@ -42,6 +42,6 @@ limitations under the License.
     cursor: pointer;
 
     font-size: 15px;
-    padding-left: 12px;
-    padding-right: 12px;
+    padding: 0 11px;
+    word-break: break-word;
 }

--- a/src/skins/vector/css/matrix-react-sdk/structures/_LoginBox.scss
+++ b/src/skins/vector/css/matrix-react-sdk/structures/_LoginBox.scss
@@ -42,4 +42,6 @@ limitations under the License.
     cursor: pointer;
 
     font-size: 15px;
+    padding-left: 12px;
+    padding-right: 12px;
 }


### PR DESCRIPTION
For some languages the register and/or login buttons are to small, which causes the text to overflow. With this fix the buttons expand to fit the text content and if needed wrap to two lines if both buttons can't fit into one line. Issue: https://github.com/vector-im/riot-web/issues/4804
![image](https://user-images.githubusercontent.com/11379925/29636448-f5bf7cac-8850-11e7-829e-67761e01337c.png)

![image](https://user-images.githubusercontent.com/11379925/29636476-14247eae-8851-11e7-8a19-25fa4f9126c7.png)

Signed-off-by: Lion Marlon n0stradamos@mail.ru