### PR TITLE
Remove width atribute to fix word wrapping

### DIFF
--- a/src/skins/vector/css/matrix-react-sdk/views/rooms/_RoomSettings.scss
+++ b/src/skins/vector/css/matrix-react-sdk/views/rooms/_RoomSettings.scss
@@ -48,7 +48,6 @@ limitations under the License.
     position: absolute;
     top: 110%;
     left: -26%;
-    width: 150%;
     padding: 2%;
     font-size: 10pt;
     line-height: 1.5em;


### PR DESCRIPTION
With a width attribute it does a weird word wrapping in german. Removing this fixed this issue.

Before:
![image](https://user-images.githubusercontent.com/1374914/30034007-ef2a0db0-919e-11e7-84a4-37d45373b3ef.png)


After:
![image](https://user-images.githubusercontent.com/1374914/30034020-fd6e459e-919e-11e7-8c91-9a3ec1164fd0.png)
