### PR TITLE
Bring back dark theme code block border

### DIFF
--- a/src/skins/vector/css/themes/_dark.scss
+++ b/src/skins/vector/css/themes/_dark.scss
@@ -131,6 +131,9 @@ $progressbar-color: #000;
 }
 
 // markdown overrides:
+.mx_EventTile_content .markdown-body pre:hover {
+    border-color: #808080 !important; // inverted due to rules below
+}
 .mx_EventTile_content .markdown-body {
     pre, code {
         filter: invert(1);


### PR DESCRIPTION
This fixes https://github.com/vector-im/riot-web/issues/5013 and https://github.com/vector-im/riot-web/issues/4416 by only showing the border when the code block is hovered, and that the border is actually visible. The !important is needed to override the default border behaviour.