### PR TITLE
Fix test for new behaviour of 'joining' flag

### DIFF
--- a/test/app-tests/joining.js
+++ b/test/app-tests/joining.js
@@ -176,6 +176,10 @@ describe('joining a room', function () {
 
                 return Promise.delay(1);
             }).then(() => {
+                // NB. we don't expect the 'joining' flag to reset at any point:
+                // it will stay set and we observe whether we have Room object for
+                // the room and whether our member event shows we're joined.
+
                 // now send the room down the /sync pipe
                 httpBackend.when('GET', '/sync').
                     respond(200, {

--- a/test/app-tests/joining.js
+++ b/test/app-tests/joining.js
@@ -176,9 +176,6 @@ describe('joining a room', function () {
 
                 return Promise.delay(1);
             }).then(() => {
-                // We've joined, expect this to false
-                expect(roomView.state.joining).toBe(false);
-
                 // now send the room down the /sync pipe
                 httpBackend.when('GET', '/sync').
                     respond(200, {


### PR DESCRIPTION
It's no longer reset when the join request completes, so don't
assert it. (The important test is later, asserting that the room
object is non-null).