### PR TITLE
fix really dumb blunder/typo preventing system from going to sleep.

### DIFF
--- a/electron_app/src/electron-main.js
+++ b/electron_app/src/electron-main.js
@@ -84,7 +84,7 @@ let powerSaveBlockerId;
 electron.ipcMain.on('app_onAction', function(ev, payload) {
     switch (payload.action) {
         case 'call_state':
-            if (powerSaveBlockerId && powerSaveBlockerId.isStarted(powerSaveBlockerId)) {
+            if (powerSaveBlockerId && electron.powerSaveBlocker.isStarted(powerSaveBlockerId)) {
                 if (payload.state === 'ended') {
                     electron.powerSaveBlocker.stop(powerSaveBlockerId);
                 }


### PR DESCRIPTION
an int obviously has no `isStarted` method - DUH

Signed-off-by: Michael Telatynski <7t3chguy@gmail.com>