### PR TITLE
Alter opacity for flair

### DIFF
--- a/src/skins/vector/css/matrix-react-sdk/views/rooms/_EventTile.scss
+++ b/src/skins/vector/css/matrix-react-sdk/views/rooms/_EventTile.scss
@@ -45,7 +45,6 @@ limitations under the License.
 
 .mx_EventTile .mx_SenderProfile {
     color: $primary-fg-color;
-    opacity: 0.5;
     font-size: 14px;
     display: block; /* anti-zalgo, with overflow hidden */
     overflow-y: hidden;
@@ -55,6 +54,15 @@ limitations under the License.
     padding-top: 0px;
     margin: 0px;
     line-height: 22px;
+}
+
+.mx_EventTile .mx_SenderProfile .mx_SenderProfile_name,
+.mx_EventTile .mx_SenderProfile .mx_SenderProfile_aux {
+    opacity: 0.5;
+}
+
+.mx_EventTile .mx_SenderProfile .mx_Flair {
+    opacity: 0.7;
 }
 
 .mx_EventTile .mx_MessageTimestamp {


### PR DESCRIPTION
Apply 0.7 opacity to flair, but keep name and aux at 0.5

codep https://github.com/matrix-org/matrix-react-sdk/pull/1401