### PR TITLE
Add padding-right to Dialogs

### DIFF
--- a/src/skins/vector/css/_common.scss
+++ b/src/skins/vector/css/_common.scss
@@ -153,6 +153,7 @@ textarea {
     font-size: 15px;
     position: relative;
     padding-left: 58px;
+    padding-right: 58px;
     padding-bottom: 36px;
     width: 60%;
     max-width: 704px;

--- a/src/skins/vector/css/_common.scss
+++ b/src/skins/vector/css/_common.scss
@@ -153,7 +153,6 @@ textarea {
     font-size: 15px;
     position: relative;
     padding-left: 58px;
-    padding-right: 58px;
     padding-bottom: 36px;
     width: 60%;
     max-width: 704px;

--- a/src/skins/vector/css/matrix-react-sdk/views/dialogs/_ChatInviteDialog.scss
+++ b/src/skins/vector/css/matrix-react-sdk/views/dialogs/_ChatInviteDialog.scss
@@ -14,6 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+.mx_ChatInviteDialog {
+    /* XXX: padding-left is on mx_Dialog but padding-right has subsequently
+     * been added on other dialogs. Surely all our dialogs should have consistent
+     * right hand padding?
+     */
+    padding-right: 58px;
+}
+
 /* Using a textarea for this element, to circumvent autofill */
 .mx_ChatInviteDialog_input,
 .mx_ChatInviteDialog_input:focus


### PR DESCRIPTION
The "groups will be public" warning was apparently the first thing
long enough to reach the right hand edge