### PR TITLE
Prevent group name looking clickable for non-members

### DIFF
--- a/src/skins/vector/css/matrix-react-sdk/structures/_GroupView.scss
+++ b/src/skins/vector/css/matrix-react-sdk/structures/_GroupView.scss
@@ -68,7 +68,7 @@ limitations under the License.
     box-shadow: none;
 }
 
-.mx_GroupView_header_name:hover div:not(.mx_GroupView_editable) {
+.mx_GroupView_header_isUserMember .mx_GroupView_header_name:hover div:not(.mx_GroupView_editable) {
     color: $accent-color;
     cursor: pointer;
 }


### PR DESCRIPTION
Part of https://github.com/matrix-org/matrix-react-sdk/pull/1559