### PR TITLE
Use margin to separate "perms" in the room directory

### DIFF
--- a/src/components/structures/RoomDirectory.js
+++ b/src/components/structures/RoomDirectory.js
@@ -409,7 +409,7 @@ module.exports = React.createClass({
 
             perms = null;
             if (guestRead || guestJoin) {
-                perms = <div className="mx_RoomDirectory_perms">{guestRead} {guestJoin}</div>;
+                perms = <div className="mx_RoomDirectory_perms">{guestRead}{guestJoin}</div>;
             }
 
             var topic = rooms[i].topic || '';

--- a/src/skins/vector/css/vector-web/structures/_RoomDirectory.scss
+++ b/src/skins/vector/css/vector-web/structures/_RoomDirectory.scss
@@ -100,6 +100,7 @@ limitations under the License.
     display: inline;
     padding-left: 5px;
     padding-right: 5px;
+    margin-right: 5px;
     height: 15px;
     border-radius: 11px;
     background-color: $plinth-bg-color;


### PR DESCRIPTION
instead of a space.

CSS applies to the room list in GroupView, so will fix the weirdness where the perms are sandwiched. 