### PR TITLE
Do not init a group store when no groupId specified

### DIFF
--- a/src/components/structures/RightPanel.js
+++ b/src/components/structures/RightPanel.js
@@ -127,8 +127,9 @@ module.exports = React.createClass({
     },
 
     _initGroupStore(groupId) {
+        if (!groupId) return;
         this._groupStore = GroupStoreCache.getGroupStore(
-            this.context.matrixClient, this.props.groupId,
+            this.context.matrixClient, groupId,
         );
         this._groupStore.registerListener(this.onGroupStoreUpdated);
     },


### PR DESCRIPTION
(in RightPanel), otherwise the store will happily send requests to the server for the `undefined` group.

Should fix https://github.com/vector-im/riot-web/issues/5513

Related: https://github.com/matrix-org/matrix-react-sdk/pull/1576