### PR TITLE
Fix wrapping of long room topics (and overlap with apps)

### DIFF
--- a/src/skins/vector/css/matrix-react-sdk/views/rooms/_AppsDrawer.scss
+++ b/src/skins/vector/css/matrix-react-sdk/views/rooms/_AppsDrawer.scss
@@ -14,9 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-.mx_AppsDrawer {
-    margin-bottom: 3px;
-}
+// .mx_AppsDrawer {
+// }
 
 .mx_AppsContainer {
     display: flex;
@@ -69,6 +68,10 @@ limitations under the License.
     // display: inline-block;
 }
 
+.mx_AppTile, .mx_AppTileFullWidth {
+    margin-bottom: 3px;
+}
+
 .mx_AppTileMenuBar {
     // height: 15px;
     margin: 0;
@@ -116,8 +119,8 @@ limitations under the License.
     display: block;
 }
 
-.mx_CloseAppWidget {
-}
+// .mx_CloseAppWidget {
+// }
 
 .mx_AppTileMenuBarWidgetPadding {
     margin-right: 5px;

--- a/src/skins/vector/css/matrix-react-sdk/views/rooms/_RoomHeader.scss
+++ b/src/skins/vector/css/matrix-react-sdk/views/rooms/_RoomHeader.scss
@@ -185,6 +185,7 @@ limitations under the License.
     overflow: hidden;
     text-overflow: ellipsis;
     border-bottom: 1px solid transparent;
+    column-width: 960px;
 }
 
 .mx_RoomHeader_avatar {

--- a/src/skins/vector/css/matrix-react-sdk/views/rooms/_RoomHeader.scss
+++ b/src/skins/vector/css/matrix-react-sdk/views/rooms/_RoomHeader.scss
@@ -22,7 +22,7 @@ limitations under the License.
 .mx_RoomHeader_wrapper {
     max-width: 960px;
     margin: auto;
-    height: 70px;
+    height: 73px;
     align-items: center;
     display: flex;
 }

--- a/src/skins/vector/css/matrix-react-sdk/views/rooms/_RoomHeader.scss
+++ b/src/skins/vector/css/matrix-react-sdk/views/rooms/_RoomHeader.scss
@@ -22,7 +22,7 @@ limitations under the License.
 .mx_RoomHeader_wrapper {
     max-width: 960px;
     margin: auto;
-    height: 73px;
+    height: 70px;
     align-items: center;
     display: flex;
 }
@@ -176,7 +176,7 @@ limitations under the License.
 .mx_RoomHeader_topic {
     vertical-align: bottom;
     float: left;
-    max-height: 42px;
+    max-height: 38px;
     color: $settings-grey-fg-color;
     font-weight: 300;
     font-size: 13px;


### PR DESCRIPTION
.mx_RoomHeader_wrapper height needs to be increased to prevent max height of child elements from overflowing allocated space (.mx_RoomHeader_topic.max-height: 42px + .mx_RoomHeader_name.height: 31px == 73px total). Wrapper element height is currently set to 70px.

Setting a column width on the room topic causes overflow to be wrapped to another column (right) and hidden (by existing "overflow: hidden", directive).