### PR TITLE
Center mixed content warnings in panel.

### DIFF
--- a/src/skins/vector/css/matrix-react-sdk/views/rooms/_AppsDrawer.scss
+++ b/src/skins/vector/css/matrix-react-sdk/views/rooms/_AppsDrawer.scss
@@ -193,8 +193,12 @@ form.mx_Custom_Widget_Form div {
 
 .mx_AppPermissionWarning {
     text-align: center;
-    padding: 30px 0;
     background-color: $primary-bg-color;
+    display: flex;
+    height: 100%;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
 }
 
 .mx_AppPermissionWarningImage {


### PR DESCRIPTION
Mixed content warnings should be centered in the app panel.

Before:
<img width="1048" alt="screen shot 2017-11-10 at 16 14 53" src="https://user-images.githubusercontent.com/6763606/32667460-a125a098-c632-11e7-8aa5-553bb1bc4c98.png">

After:
<img width="1057" alt="screen shot 2017-11-10 at 16 08 51" src="https://user-images.githubusercontent.com/6763606/32667469-aadd3466-c632-11e7-918e-1fac8f5987f3.png">
