### PR TITLE
Align text to left also when using RTL languages in room topic

### DIFF
--- a/src/skins/vector/css/matrix-react-sdk/views/rooms/_RoomHeader.scss
+++ b/src/skins/vector/css/matrix-react-sdk/views/rooms/_RoomHeader.scss
@@ -178,6 +178,7 @@ limitations under the License.
     text-overflow: ellipsis;
     border-bottom: 1px solid transparent;
     column-width: 960px;
+    text-align: left;
 }
 
 .mx_RoomHeader_avatar {


### PR DESCRIPTION
Because of using `dir=auto` attribute in the topic header container, if using RTL language the text is aligned to the right, and it's look like a mass.

So I added `text-align: left` property to the containing element.