### PR TITLE
Make sure the SettingsStore is ready to load the theme before loading it

### DIFF
--- a/src/vector/index.js
+++ b/src/vector/index.js
@@ -79,6 +79,7 @@ import Platform from './platform';
 import MatrixClientPeg from 'matrix-react-sdk/lib/MatrixClientPeg';
 import SettingsStore, {SettingLevel} from "matrix-react-sdk/lib/settings/SettingsStore";
 import Tinter from 'matrix-react-sdk/lib/Tinter';
+import SdkConfig from "matrix-react-sdk/lib/SdkConfig";
 
 var lastLocationHashSet = null;
 
@@ -295,6 +296,7 @@ async function loadApp() {
     } catch (e) {
         configError = e;
     }
+    SdkConfig.put(configJson);
 
     // as quickly as we possibly can, set a default theme...
     const styleElements = Object.create(null);

--- a/src/vector/index.js
+++ b/src/vector/index.js
@@ -263,6 +263,9 @@ async function loadApp() {
     } catch (e) {
         configError = e;
     }
+    
+    // XXX: We call this twice, once here and once in MatrixChat as a prop. We call it here to ensure
+    // granular settings are loaded correctly and to avoid duplicating the override logic for the theme. 
     SdkConfig.put(configJson);
 
     // don't try to redirect to the native apps if we're

--- a/src/vector/index.js
+++ b/src/vector/index.js
@@ -301,7 +301,7 @@ async function loadApp() {
     // as quickly as we possibly can, set a default theme...
     const styleElements = Object.create(null);
     let a;
-    const theme = SettingsStore.getValueAt(SettingLevel.DEFAULT, "theme");
+    const theme = SettingsStore.getValue("theme");
     for (let i = 0; (a = document.getElementsByTagName("link")[i]); i++) {
         const href = a.getAttribute("href");
         if (!href) continue;


### PR DESCRIPTION
# Required PRs
* https://github.com/matrix-org/matrix-react-sdk/pull/1617

# Description
This PR contains a fix for https://github.com/vector-im/riot-web/issues/5623 in addition to one other fix. The config has to be loaded (and set) before calling `SettingsStore` otherwise all settings at the `config` level are ignored. Further, it helps to call `getValue` instead of `getValueAt` if we want the config to be respected.

The other included fix is to make sure the config is loaded prior to checking the user agent. This is so the default theme check reacts correctly, as per the above.

Visibility of what is going on in the diff might be a bit unclear, so going commit by commit may be better. The summary is the flow is now: load config -> check if mobile -> set theme -> rest of loading stuff