### PR TITLE
Exclude the default language on page load

### DIFF
--- a/src/vector/index.js
+++ b/src/vector/index.js
@@ -370,7 +370,7 @@ async function loadApp() {
 }
 
 async function loadLanguage() {
-    const prefLang = SettingsStore.getValue("language");
+    const prefLang = SettingsStore.getValue("language", null, /*excludeDefault=*/true);
     let langs = [];
 
     if (!prefLang) {


### PR DESCRIPTION
This is so we correctly detect the browser language.

Fixes https://github.com/vector-im/riot-web/issues/5632

Signed-off-by: Travis Ralston <travpc@gmail.com>