### PR TITLE
Implement message-hiding

### DIFF
--- a/src/components/views/context_menus/MessageContextMenu.js
+++ b/src/components/views/context_menus/MessageContextMenu.js
@@ -123,6 +123,11 @@ module.exports = React.createClass({
         this.closeMenu();
     },
 
+    onHideUnhideClick: function() {
+        this.props.eventTileOps.toggleBodyHidden();
+        this.closeMenu();
+    },
+
     onCancelSendClick: function() {
         Resend.removeFromQueue(this.props.mxEvent);
         this.closeMenu();
@@ -181,6 +186,7 @@ module.exports = React.createClass({
         const eventStatus = this.props.mxEvent.status;
         let resendButton;
         let redactButton;
+        let hideUnhideButton;
         let cancelButton;
         let forwardButton;
         let pinButton;
@@ -203,6 +209,14 @@ module.exports = React.createClass({
             redactButton = (
                 <div className="mx_MessageContextMenu_field" onClick={this.onRedactClick}>
                     { _t('Remove') }
+                </div>
+            );
+        }
+
+        if (!eventStatus) {
+            hideUnhideButton = (
+                <div className="mx_MessageContextMenu_field" onClick={this.onHideUnhideClick}>
+                    { this.props.eventTileOps.isBodyHidden() ? _t("Unhide") : _t("Hide") }
                 </div>
             );
         }
@@ -248,7 +262,7 @@ module.exports = React.createClass({
             );
         }
 
-        if (this.props.eventTileOps) {
+        if (this.props.eventTileOps.isWidgetHidden) {
             if (this.props.eventTileOps.isWidgetHidden()) {
                 unhidePreviewButton = (
                     <div className="mx_MessageContextMenu_field" onClick={this.onUnhidePreviewClick}>
@@ -266,7 +280,7 @@ module.exports = React.createClass({
             </div>
         );
 
-        if (this.props.eventTileOps && this.props.eventTileOps.getInnerText) {
+        if (this.props.eventTileOps.getInnerText) {
             quoteButton = (
                 <div className="mx_MessageContextMenu_field" onClick={this.onQuoteClick}>
                     { _t('Quote') }
@@ -289,6 +303,7 @@ module.exports = React.createClass({
             <div>
                 {resendButton}
                 {redactButton}
+                {hideUnhideButton}
                 {cancelButton}
                 {forwardButton}
                 {pinButton}

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -124,6 +124,8 @@
     "This will allow you to return to your account after signing out, and sign in on other devices.": "This will allow you to return to your account after signing out, and sign in on other devices.",
     "You cannot delete this message. (%(code)s)": "You cannot delete this message. (%(code)s)",
     "Resend": "Resend",
+    "Unhide": "Unhide",
+    "Hide": "Hide",
     "Cancel Sending": "Cancel Sending",
     "Forward Message": "Forward Message",
     "Unpin Message": "Unpin Message",

--- a/src/skins/vector/css/matrix-react-sdk/views/rooms/_EventTile.scss
+++ b/src/skins/vector/css/matrix-react-sdk/views/rooms/_EventTile.scss
@@ -153,7 +153,8 @@ limitations under the License.
     color: $event-notsent-color;
 }
 
-.mx_EventTile_redacted .mx_EventTile_line .mx_UnknownBody {
+.mx_EventTile_redacted .mx_EventTile_line .mx_UnknownBody,
+.mx_HiddenBody {
     display: block;
     width: 100%;
     height: 22px;


### PR DESCRIPTION
Add a "Hide"/"Unhide" item to the message context menu which hides the event
body for message events.  The placeholder text for hidden messages is easily
mistaken for an actual message body, so this needs to be changed next.

Addresses vector-im/riot-web#5649

Goes with PR matrix-org/matrix-react-sdk#1657