### PR TITLE
Instructions on security issues

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,3 +1,5 @@
+<!-- Please report security issues by email to security@matrix.org -->
+
 <!-- This is a bug report template. By following the instructions below and
 filling out the sections with your information, you will help the us to get all
 the necessary data to fix your issue.


### PR DESCRIPTION
It's not good to put potentially sensitive security issues in the public bug tracker, so advice to use security@matrix.org instead