### PR TITLE
Add a snap package (https://snapcraft.io)

### DIFF
--- a/package.json
+++ b/package.json
@@ -168,12 +168,18 @@
       "webapp/**/*"
     ],
     "linux": {
-      "target": "deb",
+      "target": [
+        "deb",
+        "snap"
+      ],
       "category": "Network;InstantMessaging;Chat",
       "maintainer": "support@riot.im",
       "desktop": {
         "StartupWMClass": "riot"
       }
+    },
+    "snap": {
+      "plugs": ["default", "desktop"]
     },
     "win": {
       "target": "squirrel"


### PR DESCRIPTION
Hi! I put together this PR to add a [snap](https://snapcraft.io) package. I've tested it on Ubuntu 16.04 and 17.10, but it should work just as well on Linux Mint, Manjaro, Debian, OpenSUSE, Solus, etc.

If you merge and `yarn run build:electron` it will create `electron_app/dist/riot-web_0.13.3_amd64.snap`.

Copy this to a Linux system, [enable snap support](https://docs.snapcraft.io/core/install), then run:
`sudo snap install --dangerous riot-web_0.13.3_amd64.snap`

Run with `riot-web` or find it in the launcher.

If you create a developer account and push this to the Snap Store, it can be discovered and installed through GNOME Software and https://snapcraft.io/discover. To create the developer account, [sign up here](https://dashboard.snapcraft.io/dev/account/), then [register the "riot-web" name](https://dashboard.snapcraft.io/register-snap/?name=riot-web).

You'll need the `snapcraft` command to push the snap file to the store.
* If you're on a Mac, you can `brew install snapcraft`
* If you're on Linux, it's `sudo snap install --classic snapcraft`

Then you can push Riot out with:
`snapcraft push riot-web_0.13.3_amd64.snap --release stable`

(You can also push to the Snap Store [programmatically from Travis](https://docs.snapcraft.io/build-snaps/ci-integration#using-travis).)

Signed-off-by: Evan Dandrea \<evan@dandrea.co.uk\>