### PR TITLE
Split MImageBody into MFileBody to match JS Classes.

### DIFF
--- a/src/skins/vector/css/_components.scss
+++ b/src/skins/vector/css/_components.scss
@@ -46,6 +46,7 @@
 @import "./matrix-react-sdk/views/login/_InteractiveAuthEntryComponents.scss";
 @import "./matrix-react-sdk/views/login/_ServerConfig.scss";
 @import "./matrix-react-sdk/views/messages/_MEmoteBody.scss";
+@import "./matrix-react-sdk/views/messages/_MFileBody.scss";
 @import "./matrix-react-sdk/views/messages/_MImageBody.scss";
 @import "./matrix-react-sdk/views/messages/_MNoticeBody.scss";
 @import "./matrix-react-sdk/views/messages/_MTextBody.scss";

--- a/src/skins/vector/css/matrix-react-sdk/views/messages/_MFileBody.scss
+++ b/src/skins/vector/css/matrix-react-sdk/views/messages/_MFileBody.scss
@@ -21,6 +21,7 @@ limitations under the License.
 .mx_MFileBody_download a {
     color: $accent-color;
     text-decoration: none;
+    cursor: pointer;
 }
 
 .mx_MFileBody_download object {

--- a/src/skins/vector/css/matrix-react-sdk/views/messages/_MFileBody.scss
+++ b/src/skins/vector/css/matrix-react-sdk/views/messages/_MFileBody.scss
@@ -1,0 +1,46 @@
+/*
+Copyright 2015, 2016 OpenMarket Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+.mx_MFileBody_download {
+    color: $accent-color;
+}
+
+.mx_MFileBody_download a {
+    color: $accent-color;
+    text-decoration: none;
+}
+
+.mx_MFileBody_download object {
+    margin-left: -16px;
+    padding-right: 4px;
+    margin-top: -4px;
+    vertical-align: middle;
+    pointer-events: none;
+}
+
+/* Remove the border and padding for iframes for download links. */
+.mx_MFileBody_download iframe {
+    margin: 0px;
+    padding: 0px;
+    border: none;
+    width: 100%;
+    /* Set the height of the iframe to be 1 line of text.
+     * Iframes don't automatically size themselves to fit their content.
+     * So either we have to fix the height of the iframe using CSS or
+     * use javascript's cross-origin postMessage API to communicate how
+     * big the content of the iframe is. */
+    height: 1.5em;
+}

--- a/src/skins/vector/css/matrix-react-sdk/views/messages/_MImageBody.scss
+++ b/src/skins/vector/css/matrix-react-sdk/views/messages/_MImageBody.scss
@@ -27,34 +27,3 @@ limitations under the License.
     border-radius: 1px;
 */
 }
-
-.mx_MImageBody_download {
-    color: $accent-color;
-}
-
-.mx_MImageBody_download a {
-    color: $accent-color;
-    text-decoration: none;
-}
-
-.mx_MImageBody_download object {
-    margin-left: -16px;
-    padding-right: 4px;
-    margin-top: -4px;
-    vertical-align: middle;
-    pointer-events: none;
-}
-
-/* Remove the border and padding for iframes for download links. */
-.mx_MImageBody_download iframe {
-    margin: 0px;
-    padding: 0px;
-    border: none;
-    width: 100%;
-    /* Set the height of the iframe to be 1 line of text.
-     * Iframes don't automatically size themselves to fit their content.
-     * So either we have to fix the height of the iframe using CSS or
-     * use javascript's cross-origin postMessage API to communicate how
-     * big the content of the iframe is. */
-    height: 1.5em;
-}


### PR DESCRIPTION
Add explicit cursor:pointer so calculated CSS includes it for
- usercontent.riot.im styling

Signed-off-by: Michael Telatynski <7t3chguy@gmail.com>

### Copyright left unchanged as the majority is split out of MImageBody

## Twinned with https://github.com/matrix-org/matrix-react-sdk/pull/1726
## Fixes https://github.com/vector-im/riot-web/issues/6058