### PR TITLE
Make room tagging flux-y

### DIFF
--- a/src/components/structures/LeftPanel.js
+++ b/src/components/structures/LeftPanel.js
@@ -26,7 +26,7 @@ import sdk from 'matrix-react-sdk';
 import dis from 'matrix-react-sdk/lib/dispatcher';
 import VectorConferenceHandler from '../../VectorConferenceHandler';
 
-import SettingsStore from "matrix-react-sdk/lib/settings/SettingsStore";
+import SettingsStore from 'matrix-react-sdk/lib/settings/SettingsStore';
 import TagOrderActions from 'matrix-react-sdk/lib/actions/TagOrderActions';
 import RoomListActions from 'matrix-react-sdk/lib/actions/RoomListActions';
 

--- a/src/components/structures/LeftPanel.js
+++ b/src/components/structures/LeftPanel.js
@@ -24,7 +24,6 @@ import { MatrixClient } from 'matrix-js-sdk';
 import { KeyCode } from 'matrix-react-sdk/lib/Keyboard';
 import sdk from 'matrix-react-sdk';
 import dis from 'matrix-react-sdk/lib/dispatcher';
-import MatrixClientPeg from 'matrix-react-sdk/lib/MatrixClientPeg';
 import VectorConferenceHandler from '../../VectorConferenceHandler';
 
 import SettingsStore from "matrix-react-sdk/lib/settings/SettingsStore";
@@ -206,7 +205,7 @@ var LeftPanel = React.createClass({
 
         dis.dispatch(RoomListActions.tagRoom(
             this.context.matrixClient,
-            MatrixClientPeg.get().getRoom(roomId),
+            this.context.matrixClient.getRoom(roomId),
             prevTag, newTag,
             oldIndex, newIndex,
         ), true);
@@ -223,7 +222,7 @@ var LeftPanel = React.createClass({
         const CallPreview = sdk.getComponent('voip.CallPreview');
 
         let topBox;
-        if (MatrixClientPeg.get().isGuest()) {
+        if (this.context.matrixClient.isGuest()) {
             const LoginBox = sdk.getComponent('structures.LoginBox');
             topBox = <LoginBox collapsed={ this.props.collapsed }/>;
         } else {

--- a/src/components/structures/LeftPanel.js
+++ b/src/components/structures/LeftPanel.js
@@ -17,14 +17,20 @@ limitations under the License.
 'use strict';
 
 import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import { DragDropContext } from 'react-beautiful-dnd';
+import { MatrixClient } from 'matrix-js-sdk';
 import { KeyCode } from 'matrix-react-sdk/lib/Keyboard';
 import sdk from 'matrix-react-sdk';
 import dis from 'matrix-react-sdk/lib/dispatcher';
 import MatrixClientPeg from 'matrix-react-sdk/lib/MatrixClientPeg';
-import CallHandler from 'matrix-react-sdk/lib/CallHandler';
-import AccessibleButton from 'matrix-react-sdk/lib/components/views/elements/AccessibleButton';
 import VectorConferenceHandler from '../../VectorConferenceHandler';
+
+import SettingsStore from "matrix-react-sdk/lib/settings/SettingsStore";
+import TagOrderActions from 'matrix-react-sdk/lib/actions/TagOrderActions';
+import RoomListActions from 'matrix-react-sdk/lib/actions/RoomListActions';
+
 
 var LeftPanel = React.createClass({
     displayName: 'LeftPanel',
@@ -32,7 +38,11 @@ var LeftPanel = React.createClass({
     // NB. If you add props, don't forget to update
     // shouldComponentUpdate!
     propTypes: {
-        collapsed: React.PropTypes.bool.isRequired,
+        collapsed: PropTypes.bool.isRequired,
+    },
+
+    contextTypes: {
+        matrixClient: PropTypes.instanceOf(MatrixClient),
     },
 
     getInitialState: function() {
@@ -161,8 +171,54 @@ var LeftPanel = React.createClass({
         this.setState({ searchFilter: term });
     },
 
+    onDragEnd: function(result) {
+        // Dragged to an invalid destination, not onto a droppable
+        if (!result.destination) {
+            return;
+        }
+
+        const dest = result.destination.droppableId;
+
+        if (dest === 'tag-panel-droppable') {
+            // Dispatch synchronously so that the TagPanel receives an
+            // optimistic update from TagOrderStore before the previous
+            // state is shown.
+            dis.dispatch(TagOrderActions.moveTag(
+                this.context.matrixClient,
+                result.draggableId,
+                result.destination.index,
+            ), true);
+        } else {
+            this.onRoomTileEndDrag(result);
+        }
+    },
+
+    onRoomTileEndDrag: function(result) {
+        let newTag = result.destination.droppableId.split('_')[1];
+        let prevTag = result.source.droppableId.split('_')[1];
+        if (newTag === 'undefined') newTag = undefined;
+        if (prevTag === 'undefined') prevTag = undefined;
+
+        const roomId = result.draggableId.split('_')[1];
+
+        const oldIndex = result.source.index;
+        const newIndex = result.destination.index;
+
+        dis.dispatch(RoomListActions.tagRoom(
+            this.context.matrixClient,
+            MatrixClientPeg.get().getRoom(roomId),
+            prevTag, newTag,
+            oldIndex, newIndex,
+        ), true);
+    },
+
+    collectRoomList: function(ref) {
+        this._roomList = ref;
+    },
+
     render: function() {
         const RoomList = sdk.getComponent('rooms.RoomList');
+        const TagPanel = sdk.getComponent('structures.TagPanel');
         const BottomLeftMenu = sdk.getComponent('structures.BottomLeftMenu');
         const CallPreview = sdk.getComponent('voip.CallPreview');
 
@@ -184,15 +240,21 @@ var LeftPanel = React.createClass({
         );
 
         return (
-            <aside className={classes} onKeyDown={ this._onKeyDown } onFocus={ this._onFocus } onBlur={ this._onBlur }>
-                { topBox }
-                <CallPreview ConferenceHandler={VectorConferenceHandler} />
-                <RoomList
-                    collapsed={this.props.collapsed}
-                    searchFilter={this.state.searchFilter}
-                    ConferenceHandler={VectorConferenceHandler} />
-                <BottomLeftMenu collapsed={this.props.collapsed}/>
-            </aside>
+            <DragDropContext onDragEnd={this.onDragEnd}>
+                <div className="mx_LeftPanel_container">
+                    { SettingsStore.isFeatureEnabled("feature_tag_panel") ? <TagPanel /> : <div /> }
+                    <aside className={classes} onKeyDown={ this._onKeyDown } onFocus={ this._onFocus } onBlur={ this._onBlur }>
+                        { topBox }
+                        <CallPreview ConferenceHandler={VectorConferenceHandler} />
+                        <RoomList
+                            ref={this.collectRoomList}
+                            collapsed={this.props.collapsed}
+                            searchFilter={this.state.searchFilter}
+                            ConferenceHandler={VectorConferenceHandler} />
+                        <BottomLeftMenu collapsed={this.props.collapsed}/>
+                    </aside>
+                </div>
+            </DragDropContext>
         );
     }
 });

--- a/src/components/structures/RoomSubList.js
+++ b/src/components/structures/RoomSubList.js
@@ -572,13 +572,17 @@ var RoomSubList = React.createClass({
                 { subList }
             </div>;
 
-            return this.props.editable ? <Droppable droppableId={"room-sub-list-droppable_" + this.props.tagName}>
-                { (provided, snapshot) => (
-                    <div ref={provided.innerRef}>
-                        { subListContent }
-                    </div>
-                ) }
-            </Droppable> : subListContent;
+            return this.props.editable ?
+                <Droppable
+                    droppableId={"room-sub-list-droppable_" + this.props.tagName}
+                    type="draggable-RoomTile"
+                >
+                    { (provided, snapshot) => (
+                        <div ref={provided.innerRef}>
+                            { subListContent }
+                        </div>
+                    ) }
+                </Droppable> : subListContent;
         }
         else {
             var Loader = sdk.getComponent("elements.Spinner");

--- a/src/components/views/context_menus/RoomTileContextMenu.js
+++ b/src/components/views/context_menus/RoomTileContextMenu.js
@@ -59,42 +59,16 @@ module.exports = React.createClass({
     },
 
     _toggleTag: function(tagNameOn, tagNameOff) {
-        var self = this;
-        const roomId = this.props.room.roomId;
-        var cli = MatrixClientPeg.get();
-        if (!cli.isGuest()) {
-            Promise.delay(500).then(function() {
-                if (tagNameOff !== null && tagNameOff !== undefined) {
-                    cli.deleteRoomTag(roomId, tagNameOff).finally(function() {
-                        // Close the context menu
-                        if (self.props.onFinished) {
-                            self.props.onFinished();
-                        };
-                    }).catch(function(err) {
-                        var ErrorDialog = sdk.getComponent("dialogs.ErrorDialog");
-                        Modal.createTrackedDialog('Failed to remove tag from room 1', '', ErrorDialog, {
-                            title: _t('Failed to remove tag %(tagName)s from room', {tagName: tagNameOff}),
-                            description: ((err && err.message) ? err.message : _t('Operation failed')),
-                        });
-                    });
-                }
+        if (!MatrixClientPeg.get().isGuest()) {
+            Promise.delay(500).then(() => {
+                dis.dispatch(RoomListActions.tagRoom(
+                    MatrixClientPeg.get(),
+                    this.props.room,
+                    tagNameOff, tagNameOn,
+                    undefined, 0,
+                ), true);
 
-                if (tagNameOn !== null && tagNameOn !== undefined) {
-                    // If the tag ordering meta data is required, it is added by
-                    // the RoomSubList when it sorts its rooms
-                    cli.setRoomTag(roomId, tagNameOn, {}).finally(function() {
-                        // Close the context menu
-                        if (self.props.onFinished) {
-                            self.props.onFinished();
-                        };
-                    }).catch(function(err) {
-                        var ErrorDialog = sdk.getComponent("dialogs.ErrorDialog");
-                        Modal.createTrackedDialog('Failed to remove tag from room 2', '', ErrorDialog, {
-                            title: _t('Failed to remove tag %(tagName)s from room', {tagName: tagNameOn}),
-                            description: ((err && err.message) ? err.message : _t('Operation failed')),
-                        });
-                    });
-                }
+                this.props.onFinished();
             });
         }
     },

--- a/src/components/views/rooms/DNDRoomTile.js
+++ b/src/components/views/rooms/DNDRoomTile.js
@@ -41,6 +41,7 @@ export default class DNDRoomTile extends React.Component {
                 key={props.room.roomId}
                 draggableId={props.tagName + '_' + props.room.roomId}
                 index={props.index}
+                type="draggable-RoomTile"
             >
                 { (provided, snapshot) => {
                     return (

--- a/src/skins/vector/css/vector-web/structures/_LeftPanel.scss
+++ b/src/skins/vector/css/vector-web/structures/_LeftPanel.scss
@@ -21,6 +21,10 @@ limitations under the License.
     flex-direction: column;
 }
 
+.mx_LeftPanel_container {
+    display: flex;
+}
+
 .mx_LeftPanel_hideButton {
     position: absolute;
     top: 10px;


### PR DESCRIPTION
 - Moves RoomTileContextMenu over to new async action to set room tags.
 - Adds a DragDropContext that handles drag and drop for TagPanel and RoomList. This is to
allow the future feature of dragging between the two components.
 - Prevents RoomTiles from being dragged elsewhere for the time being.

See matrix-org/matrix-react-sdk#1719