### PR TITLE
Fix horizontal scrollbar under certain circumstances

### DIFF
--- a/src/skins/vector/css/matrix-react-sdk/views/rooms/_MessageComposer.scss
+++ b/src/skins/vector/css/matrix-react-sdk/views/rooms/_MessageComposer.scss
@@ -108,6 +108,10 @@ limitations under the License.
     padding-top: 2px;
 }
 
+.mx_MessageComposer .public-DraftStyleDefault-block {
+    overflow-x: hidden;
+}
+
 .mx_MessageComposer_input blockquote {
     color: $blockquote-fg-color;
     margin: 0 0 16px;


### PR DESCRIPTION
specifically when trailing whitespace is not wrapped onto the next
line of the block.

Fixes #6077