### PR TITLE
Use translucent black for RoomSubList bg to fix tinting

### DIFF
--- a/src/skins/vector/css/themes/_base.scss
+++ b/src/skins/vector/css/themes/_base.scss
@@ -104,7 +104,7 @@ $roomtile-name-color: rgba(69, 69, 69, 0.8);
 $roomtile-selected-bg-color: rgba(255, 255, 255, 0.8);
 $roomtile-focused-bg-color: rgba(255, 255, 255, 0.9);
 
-$roomsublist-background: #badece;
+$roomsublist-background: rgba(0, 0, 0, 0.05);
 $roomsublist-label-fg-color: $h3-color;
 $roomsublist-label-bg-color: $tertiary-accent-color;
 $roomsublist-chevron-color: $accent-color;

--- a/src/skins/vector/css/themes/_dark.scss
+++ b/src/skins/vector/css/themes/_dark.scss
@@ -103,7 +103,7 @@ $roomtile-name-color: rgba(186, 186, 186, 0.8);
 $roomtile-selected-bg-color: #333;
 $roomtile-focused-bg-color: rgba(255, 255, 255, 0.2);
 
-$roomsublist-background: #222;
+$roomsublist-background: rgba(0, 0, 0, 0.2);
 $roomsublist-label-fg-color: $h3-color;
 $roomsublist-label-bg-color: $tertiary-accent-color;
 $roomsublist-chevron-color: $accent-color;

--- a/src/skins/vector/themes/status/css/_status.scss
+++ b/src/skins/vector/themes/status/css/_status.scss
@@ -160,7 +160,7 @@ $roomtile-name-color: #ffffff;
 $roomtile-selected-bg-color: #465561;
 $roomtile-focused-bg-color: #6d8597;
 
-$roomsublist-background: #465561;
+$roomsublist-background: rgba(0, 0, 0, 0.2);
 $roomsublist-label-fg-color: #ffffff;
 $roomsublist-label-bg-color: $secondary-accent-color;
 $roomsublist-chevron-color: #ffffff;


### PR DESCRIPTION
The alternative is to specify yet another colour that we have to
worry about when applying tinting, which is currently quite
fragile and requires changes to many parts of the app, including
all themes that don't require the colour to be tinted.

By using translucent black, we effectively take the secondary
accent colour of the LeftPanel and make it more black.

Note: This does not preserve the previous colour we were using,
although the alternative above does allow for this.

Also, this simplifies the same bg colour for the other themes.

Partially fixes https://github.com/vector-im/riot-web/issues/6159