### PR TITLE
Make dropdowns with long options degrade more gracefully

### DIFF
--- a/src/skins/vector/css/matrix-react-sdk/views/elements/_Dropdown.scss
+++ b/src/skins/vector/css/matrix-react-sdk/views/elements/_Dropdown.scss
@@ -56,6 +56,12 @@ limitations under the License.
     left: 10px;
 }
 
+.mx_Dropdown_input > .mx_Dropdown_option {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
 .mx_Dropdown.left_aligned .mx_Dropdown_input > .mx_Dropdown_option {
     padding-left: 25px;
 }
@@ -102,6 +108,11 @@ input.mx_Dropdown_option, input.mx_Dropdown_option:focus {
     background-color: $primary-bg-color;
     max-height: 200px;
     overflow-y: auto;
+}
+
+.mx_Dropdown_menu .mx_Dropdown_option {
+    height: auto;
+    min-height: 35px;
 }
 
 .mx_Dropdown_menu .mx_Dropdown_option_highlight {


### PR DESCRIPTION
If not enough space was dedicated to a dropdown,
it would previously make option text overlap.

With this patch, each option can potentially span
multiple lines. This is weird, but it's a better
degradation than making option text overlap.

Of course, a proper fix is to dedicate proper attention to each "not enough space dropdown" and allow for enough space to avoid this. But until that's done, it's better to degrade in a nicer way.

## Before

![dropdown-media-before](https://user-images.githubusercontent.com/388669/36627292-5b073fda-1949-11e8-91c1-dc05621da46f.png)

![dropdown-login-before](https://user-images.githubusercontent.com/388669/36627293-5db968fc-1949-11e8-878e-1555e9671965.png)

## After

![dropdown-media-after](https://user-images.githubusercontent.com/388669/36627295-6e3f5196-1949-11e8-836f-fe0339c9b1d3.png)

![dropdown-login-after](https://user-images.githubusercontent.com/388669/36627296-728d2c64-1949-11e8-94cf-9ae2ff9dc0c6.png)

Signed-off-by: Slavi Pantaleev <slavi@devture.com>