### PR TITLE
Make media dropdown wider

### DIFF
--- a/src/skins/vector/css/matrix-react-sdk/structures/_UserSettings.scss
+++ b/src/skins/vector/css/matrix-react-sdk/structures/_UserSettings.scss
@@ -135,8 +135,8 @@ limitations under the License.
     width: 200px;
 }
 
-.mx_UserSettings_webRtcDevices_dropdown{
-    width: 200px;
+.mx_UserSettings_webRtcDevices_dropdown {
+    width: 50%;
 }
 
 .mx_UserSettings_profileTable


### PR DESCRIPTION
The media dropdown would sometimes contain options
with long text, which can't possibly fit in 200px.
(e.g. `Monitor of Built-in Audio Digital Stereo (HDMI)`)

Dedicating some more space resolves the problem.

This is somewhat of a continuation to #6244.
Before #6244, the options just overlap in a really ugly way.
After #6244 they span multiple lines, which is better, but still not perfect.
With this, it should hopefully be ideal.

Final result:

![dropdown-media-after-50-percent](https://user-images.githubusercontent.com/388669/36627392-9179fbba-194a-11e8-96f9-d149ad15bc3f.png)

Signed-off-by: Slavi Pantaleev <slavi@devture.com>