### PR TITLE
Make sure mx_TagPanel_tagTileContainer occupies full height

### DIFF
--- a/src/skins/vector/css/matrix-react-sdk/structures/_TagPanel.scss
+++ b/src/skins/vector/css/matrix-react-sdk/structures/_TagPanel.scss
@@ -55,6 +55,8 @@ limitations under the License.
     display: flex;
     flex-direction: column;
     align-items: center;
+
+    height: 100%;
 }
 
 .mx_TagPanel .mx_TagTile {


### PR DESCRIPTION
so that the user can drag groups to an empty TagPanel

fixes https://github.com/vector-im/riot-web/issues/6276