### PR TITLE
Fix gap between avatar and border

### DIFF
--- a/src/skins/vector/css/matrix-react-sdk/structures/_TagPanel.scss
+++ b/src/skins/vector/css/matrix-react-sdk/structures/_TagPanel.scss
@@ -75,9 +75,15 @@ limitations under the License.
     padding: 3px 0px;
 }
 
-.mx_TagPanel .mx_TagTile.mx_TagTile_selected .mx_TagTile_avatar {
+.mx_TagPanel .mx_TagTile.mx_TagTile_selected .mx_TagTile_avatar .mx_BaseAvatar {
     border: 3px solid $accent-color;
+    background-color: $accent-color;
     border-radius: 60px;
+
+    /* In case this is a "initial" avatar */
+    display: block;
+    height: 35px;
+    width: 35px;
 }
 
 .mx_TagPanel .mx_TagTile.mx_AccessibleButton:focus {


### PR DESCRIPTION
With the caveat that this will give a solid background
to group avatars with transparency when they are selected.

fixes https://github.com/vector-im/riot-web/issues/6225
fixes https://github.com/vector-im/riot-web/issues/6190