### PR TITLE
Rename the Riot-Web Translations Room

### DIFF
--- a/res/home.html
+++ b/res/home.html
@@ -284,9 +284,9 @@
         <div class="mx_HomePage_room">
             <a href="#/room/#riotweb-translations:matrix.org">
                 <img class="mx_HomePage_icon" src="home/rooms/riot-translations.png">
-                <span class="mx_HomePage_name">Riot-Web Translations</span>
+                <span class="mx_HomePage_name">Riot Translations</span>
             </a>
-            <span class="mx_HomePage_desc">_t("Co-ordination for Riot/Web translators")</span>
+            <span class="mx_HomePage_desc">_t("Co-ordination for Riot translators")</span>
         </div>
     </div>
 </div>


### PR DESCRIPTION
The translations Room is also used for the non Web Versions of Riot so it made sense to change the name (the alias still exists)

Signed-Off-By: Marcel Radzio <mtrnord1 [at] gmail.com>