### PR TITLE
Add AppImage target to Linux build

### DIFF
--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
       "webapp/**/*"
     ],
     "linux": {
-      "target": "deb",
+      "target": ["deb", "AppImage"],
       "category": "Network;InstantMessaging;Chat",
       "maintainer": "support@riot.im",
       "desktop": {


### PR DESCRIPTION
Tell Electron Builder to build an AppImage as well as a Debian package.

Signed-off-by: Aidan Gauland aidalgol+ghpr@fastmail.net