### PR TITLE
Specify Node version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "type": "git",
     "url": "https://github.com/vector-im/riot-web"
   },
+  "engines": {
+    "node": ">= 6.3.0"
+  },
   "license": "Apache-2.0",
   "files": [
     "AUTHORS.rst",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/vector-im/riot-web"
   },
   "engines": {
-    "node": ">= 6.3.0"
+    "node": ">= 8.12.0"
   },
   "license": "Apache-2.0",
   "files": [


### PR DESCRIPTION
While testing and deploying to several different environments, I found it useful to indicate which version of Node is expected in `package.json`.  Following `README.md`, I've specified `>= 6.3.0` here — though it may be safe to upgrade to `8.0.0` or beyond.  Haven't run into any issues so far.