### PR TITLE
Lighten <blockquote> in dark theme

### DIFF
--- a/src/skins/vector/css/themes/_dark.scss
+++ b/src/skins/vector/css/themes/_dark.scss
@@ -196,6 +196,10 @@ $progressbar-color: #000;
             background-color: #080808;
         }
     }
+
+    blockquote {
+        color: #999999
+    }
 }
 
 // Add a line to the right side of the left panel to distinguish it from the middle panel


### PR DESCRIPTION
For the dark theme only, override the colour from gfm.css for markdown blockquotes with a lighter grey.

Fixes #5154

Signed-off-by: Aidan Gauland aidalgol+ghpr@fastmail.net