### PR TITLE
Fix confusing setting label

### DIFF
--- a/src/components/views/settings/Notifications.js
+++ b/src/components/views/settings/Notifications.js
@@ -882,7 +882,7 @@ module.exports = React.createClass({
                         </div>
                         <div className="mx_UserNotifSettings_labelCell">
                             <label htmlFor="enableDesktopAudioNotifications">
-                                { _t('Enable audible notifications in web client') }
+                                { _t('Enable audible notifications') }
                             </label>
                         </div>
                     </div>

--- a/src/i18n/strings/be.json
+++ b/src/i18n/strings/be.json
@@ -15,7 +15,6 @@
     "Directory": "Каталог",
     "Dismiss": "Aдхіліць",
     "Download this file": "Спампаваць гэты файл",
-    "Enable audible notifications in web client": "Ўключыць гукавыя апавяшчэнні ў вэб-кліенце",
     "Enable desktop notifications": "Ўключыць апавяшчэнні на працоўным стале",
     "Enable email notifications": "Ўключыць паведамлення па электроннай пошце",
     "Enable notifications for this account": "Ўключыць апавяшчэнні для гэтага ўліковага запісу",

--- a/src/i18n/strings/bg.json
+++ b/src/i18n/strings/bg.json
@@ -39,7 +39,6 @@
     "You might have configured them in a client other than Riot. You cannot tune them in Riot but they still apply": "Възможна конфигурация на настройките за известия в клиент, различен от Riot. Не могат да бъдат променени в Riot, но важат въпреки това",
     "Enable desktop notifications": "Включване на известия на работния плот",
     "Show message in desktop notification": "Показване на съдържание в известията на работния плот",
-    "Enable audible notifications in web client": "Включване на звукови известия в уеб клиент",
     "Off": "Изключено",
     "On": "Включено",
     "Noisy": "Шумно",

--- a/src/i18n/strings/ca.json
+++ b/src/i18n/strings/ca.json
@@ -27,7 +27,6 @@
     "Unnamed room": "Sala sense nom",
     "#example": "#exemple",
     "Failed to change settings": "No s'han pogut modificar els paràmetres",
-    "Enable audible notifications in web client": "Habilita les notificacions d'àudio al client web",
     "Enable desktop notifications": "Habilita les notificacions d'escriptori",
     "Enable email notifications": "Habilita les notificacions per correu electrònic",
     "Enable notifications for this account": "Habilita les notificacions per aquest compte",

--- a/src/i18n/strings/cs.json
+++ b/src/i18n/strings/cs.json
@@ -107,7 +107,6 @@
     "Collecting logs": "Sbírání logů",
     "Couldn't find a matching Matrix room": "Odpovídající Matrix místost nenalezena",
     "Delete the room alias %(alias)s and remove %(name)s from the directory?": "Smazat alias místnosti %(alias)s a odstranit %(name)s z adresáře?",
-    "Enable audible notifications in web client": "Povolit zvuková upozornění ve webové aplikaci",
     "Enable them now": "Povolit nyní",
     "Enter keywords separated by a comma:": "Vložte klíčová slova oddělená čárkou:",
     "Error saving email notification preferences": "Chyba při ukládání nastavení e-mailových upozornění",

--- a/src/i18n/strings/da.json
+++ b/src/i18n/strings/da.json
@@ -9,7 +9,6 @@
     "Direct Chat": "Personlig Chat",
     "Directory": "Rum katalog",
     "Dismiss": "Afskedige",
-    "Enable audible notifications in web client": "Aktivér hørbare underretninger i webklienten",
     "Enable desktop notifications": "Aktivér desktop meddelelser",
     "Enable email notifications": "Aktivér e-mail-underretninger",
     "Enable notifications for this account": "Aktivér underretninger for dette brugernavn",

--- a/src/i18n/strings/de_DE.json
+++ b/src/i18n/strings/de_DE.json
@@ -23,7 +23,6 @@
     "Couldn't find a matching Matrix room": "Konnte keinen entsprechenden Matrix-Raum finden",
     "delete the alias.": "Lösche den Alias.",
     "Direct Chat": "Direkt-Chat",
-    "Enable audible notifications in web client": "Audio-Benachrichtigungen im Web-Client aktivieren",
     "Enable desktop notifications": "Desktop-Benachrichtigungen aktivieren",
     "Enable email notifications": "E-Mail-Benachrichtigungen aktivieren",
     "Enable notifications for this account": "Benachrichtigungen für dieses Benutzerkonto aktivieren",

--- a/src/i18n/strings/el.json
+++ b/src/i18n/strings/el.json
@@ -17,7 +17,6 @@
     "Direct Chat": "Απευθείας συνομιλία",
     "Directory": "Ευρετήριο",
     "Download this file": "Λήψη αρχείου",
-    "Enable audible notifications in web client": "Ενεργοποίηση ηχητικών ειδοποιήσεων",
     "Enable email notifications": "Ενεργοποίηση ειδοποιήσεων μέσω μηνυμάτων ηλ. αλληλογραφίας",
     "Enable notifications for this account": "Ενεργοποίηση ειδοποιήσεων για τον λογαριασμό",
     "Enter keywords separated by a comma:": "Προσθέστε λέξεις κλειδιά χωρισμένες με κόμμα:",

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -39,7 +39,7 @@
     "You might have configured them in a client other than Riot. You cannot tune them in Riot but they still apply": "You might have configured them in a client other than Riot. You cannot tune them in Riot but they still apply",
     "Enable desktop notifications": "Enable desktop notifications",
     "Show message in desktop notification": "Show message in desktop notification",
-    "Enable audible notifications in web client": "Enable audible notifications in web client",
+    "Enable audible notifications": "Enable audible notifications",
     "Off": "Off",
     "On": "On",
     "Noisy": "Noisy",

--- a/src/i18n/strings/en_US.json
+++ b/src/i18n/strings/en_US.json
@@ -28,7 +28,6 @@
     "Directory": "Directory",
     "Dismiss": "Dismiss",
     "Download this file": "Download this file",
-    "Enable audible notifications in web client": "Enable audible notifications in web client",
     "Enable desktop notifications": "Enable desktop notifications",
     "Enable email notifications": "Enable email notifications",
     "Enable notifications for this account": "Enable notifications for this account",

--- a/src/i18n/strings/eo.json
+++ b/src/i18n/strings/eo.json
@@ -52,7 +52,6 @@
     "Custom Server Options": "Propraj servilaj elektoj",
     "customServer_text": "Vi povas uzi opciojn personigitajn de la servilo por ensaluti en aliajn servilojn Matrix specifante alian adreson URL-an de alia servilo Home.<br/>Tio permesas al vi uzi Riot per ekzistanta konto en alia Home servilo.<br/><br/>Vi povas ankaŭ agordi servilon identecan personigita, sed ne eblos inviti uzantojn pere de retpoŝtadreso, aŭ esti invitita pere de retpoŝtadreso vi mem.",
     "Delete the room alias %(alias)s and remove %(name)s from the directory?": "Ĉu forigi la ĉambran kromnomon %(alias)s kaj forigi %(name)s de la ujo?",
-    "Enable audible notifications in web client": "Ŝalti aŭdeblajn sciigojn en la retkliento",
     "Enable desktop notifications": "Ŝalti labortablajn sciigojn",
     "Enable email notifications": "Ŝalti retpoŝtajn sciigojn",
     "Enable notifications for this account": "Ŝalti sciigojn por tiu ĉi konto",

--- a/src/i18n/strings/es.json
+++ b/src/i18n/strings/es.json
@@ -15,7 +15,6 @@
     "Direct Chat": "Conversación directa",
     "Directory": "Directorio",
     "Download this file": "Descargar este archivo",
-    "Enable audible notifications in web client": "Habilitar notificaciones audibles en el cliente web",
     "Enable desktop notifications": "Habilitar notificaciones de escritorio",
     "Enable email notifications": "Habilitar notificaciones por email",
     "Enable notifications for this account": "Habilitar notificaciones para esta cuenta",

--- a/src/i18n/strings/eu.json
+++ b/src/i18n/strings/eu.json
@@ -28,7 +28,6 @@
     "Directory": "Direktorioa",
     "Dismiss": "Baztertu",
     "Download this file": "Deskargatu fitxategi hau",
-    "Enable audible notifications in web client": "Gaitu jakinarazpen entzungarriak web bezeroan",
     "Enable desktop notifications": "Gaitu mahaigaineko jakinarazpenak",
     "Enable email notifications": "Gaitu e-mail bidezko jakinarazpenak",
     "Enable notifications for this account": "Gaitu jakinarazpenak kontu honetarako",

--- a/src/i18n/strings/fa.json
+++ b/src/i18n/strings/fa.json
@@ -11,7 +11,6 @@
     "Direct Chat": "چت مستقیم",
     "Directory": "فهرست گپ‌گاه‌ها",
     "Download this file": "بارگیری کن",
-    "Enable audible notifications in web client": "آگاه‌سازی صدادار را در کارگزار وب فعال کن",
     "Enable email notifications": "آگاه‌سازی با رایانامه را فعال کن",
     "Enable notifications for this account": "آگاه سازی با رایانامه را برای این اکانت فعال کن",
     "Enable them now": "همین حالا فعالشان کن",

--- a/src/i18n/strings/fi.json
+++ b/src/i18n/strings/fi.json
@@ -95,7 +95,6 @@
     "Failed to change settings": "Asetusten muuttaminen epäonnistui",
     "Failed to forget room %(errCode)s": "Huoneen unohtaminen epäonnistui %(errCode)s",
     "Failed to update keywords": "Avainsanojen päivittäminen epäonnistui",
-    "Enable audible notifications in web client": "Ota käyttöön äänelliset ilmoitukset",
     "Enable desktop notifications": "Ota käyttöön työpöytäilmoitukset",
     "Enable email notifications": "Ota käyttöön sähköposti-ilmoitukset",
     "Enable notifications for this account": "Ota käyttöön ilmoitukset tälle tilille",

--- a/src/i18n/strings/fr.json
+++ b/src/i18n/strings/fr.json
@@ -15,7 +15,6 @@
     "Directory": "Répertoire",
     "Dismiss": "Ignorer",
     "Download this file": "Télécharger ce fichier",
-    "Enable audible notifications in web client": "Activer les notifications sonores pour le client web",
     "Enable desktop notifications": "Activer les notifications de bureau",
     "Enable email notifications": "Activer les notifications par e-mail",
     "Enable notifications for this account": "Activer les notifications pour ce compte",

--- a/src/i18n/strings/gl.json
+++ b/src/i18n/strings/gl.json
@@ -31,7 +31,6 @@
     "Directory": "Directorio",
     "Dismiss": "Rexeitar",
     "Download this file": "Descargue este ficheiro",
-    "Enable audible notifications in web client": "Habilitar notificacións audibles no cliente web",
     "Enable desktop notifications": "Habilitar notificacións de escritorio",
     "Enable email notifications": "Habilitar notificacións de correo",
     "Enable notifications for this account": "Habilitar notificacións para esta conta",

--- a/src/i18n/strings/he.json
+++ b/src/i18n/strings/he.json
@@ -26,7 +26,6 @@
     "Directory": "ספרייה",
     "Dismiss": "שחרר",
     "Download this file": "הורד את הקובץ",
-    "Enable audible notifications in web client": "אפשר התראות קוליות בדפדפן",
     "Enable desktop notifications": "אפשר התראות בשולחן העבודה",
     "Enable email notifications": "אפשר התראות באמצעות הדואר האלקטרוני",
     "Enable notifications for this account": "אפשר התראות לחשבון זה",

--- a/src/i18n/strings/hu.json
+++ b/src/i18n/strings/hu.json
@@ -17,7 +17,6 @@
     "Directory": "Könyvtár",
     "Dismiss": "Eltüntet",
     "Download this file": "Fájl letöltése",
-    "Enable audible notifications in web client": "Hangértesítések engedélyezése a webkliensben",
     "Enable desktop notifications": "Asztali értesítések engedélyezése",
     "Enable email notifications": "E-mail értesítések engedélyezése",
     "Enable notifications for this account": "Értesítések engedélyezése ehhez a fiókhoz",

--- a/src/i18n/strings/id.json
+++ b/src/i18n/strings/id.json
@@ -28,7 +28,6 @@
     "Directory": "Direktori",
     "Dismiss": "Abaikan",
     "Download this file": "Unduh file ini",
-    "Enable audible notifications in web client": "Aktifkan notifikasi suara di klien web",
     "Enable desktop notifications": "Aktifkan notifikasi desktop",
     "Enable email notifications": "Aktifkan notifikasi email",
     "Enable notifications for this account": "Aktifkan notifikasi untuk akun ini",

--- a/src/i18n/strings/it.json
+++ b/src/i18n/strings/it.json
@@ -26,7 +26,6 @@
     "Directory": "Lista",
     "Dismiss": "Scarta",
     "Download this file": "Scarica questo file",
-    "Enable audible notifications in web client": "Abilita notifiche audio nel client web",
     "Enable desktop notifications": "Abilita le notifiche desktop",
     "Enable email notifications": "Abilita le notifiche email",
     "Enable notifications for this account": "Abilita le notifiche per questo account",

--- a/src/i18n/strings/ko.json
+++ b/src/i18n/strings/ko.json
@@ -100,7 +100,6 @@
     "<a href=\"http://apple.com/safari\">Safari</a> and <a href=\"http://opera.com\">Opera</a> work too.": "<a href=\"http://apple.com/safari\">사파리</a>와 <a href=\"http://opera.com\">오페라</a>에서도 작동해요.",
     "customServer_text": "사용자 지정 서버 설정에서 다른 홈 서버 URL을 지정해 다른 매트릭스 서버에 로그인할 수 있어요.<br/>이를 통해 라이엇과 다른 홈 서버의 기존 매트릭스 계정을 함께 쓸 수 있죠.<br/><br/>사용자 지정 ID 서버를 설정할 수도 있지만 이메일 주소로 사용자를 초대하거나 초대받을 수는 없답니다.",
     "Delete the room alias %(alias)s and remove %(name)s from the directory?": "방 가명 %(alias)s 을 지우고 목록에서 %(name)s를 지우시겠어요?",
-    "Enable audible notifications in web client": "웹 클라이언트에서 알림 소리 켜기",
     "Enable them now": "지금 켜기",
     "Enter keywords separated by a comma:": "키워드를 쉼표로 구분해 입력해주세요:",
     "Failed to add tag %(tagName)s to room": "방에 %(tagName)s로 지정하지 못했어요",

--- a/src/i18n/strings/lt.json
+++ b/src/i18n/strings/lt.json
@@ -112,7 +112,6 @@
     "There are advanced notifications which are not shown here": "Yra išplėstinių pranešimų, kurie nėra čia rodomi",
     "You might have configured them in a client other than Riot. You cannot tune them in Riot but they still apply": "Jūs turbūt juos sukonfigūravote kitoje programėlėje nei Riot. Negalite jų koreguoti Riot programėlėje, bet jie vistiek yra taikomi",
     "Show message in desktop notification": "Rodyti žinutes darbalaukio pranešimuose",
-    "Enable audible notifications in web client": "Įgalinti garsinius pranešimus internetinėje aplinkoje",
     "Off": "Išjungta",
     "On": "Įjungta",
     "Noisy": "Triukšmingas",

--- a/src/i18n/strings/lv.json
+++ b/src/i18n/strings/lv.json
@@ -29,7 +29,6 @@
     "Directory": "Katalogs",
     "Dismiss": "Atteikt",
     "Download this file": "Lejupielādēt šo failu",
-    "Enable audible notifications in web client": "Iespējot skaņus paziņojumus web klientā",
     "Enable desktop notifications": "Iespējot darbvirsmas paziņojumus",
     "Enable email notifications": "Iespējot paziņojumus pa epastu",
     "Enable notifications for this account": "Iespējot paziņojumus šim kontam",

--- a/src/i18n/strings/ml.json
+++ b/src/i18n/strings/ml.json
@@ -27,7 +27,6 @@
     "Directory": "ഡയറക്ടറി",
     "Dismiss": "ഒഴിവാക്കുക",
     "Download this file": "ഈ ഫയല്‍ ഡൌണ്‍ലോഡ് ചെയ്യുക",
-    "Enable audible notifications in web client": "വെബ് പതിപ്പിലെ അറിയിപ്പുകള്‍ കേള്‍ക്കാവുന്നതാക്കുക",
     "Enable desktop notifications": "ഡെസ്ക്ടോപ്പ് നോട്ടിഫിക്കേഷനുകള്‍ ഇനേബിള്‍ ചെയ്യുക",
     "Enable email notifications": "ഇമെയില്‍ നോട്ടിഫിക്കേഷനുകള്‍ ഇനേബിള്‍ ചെയ്യുക",
     "Enable notifications for this account": "ഈ അക്കൌണ്ടില്‍ നോട്ടിഫിക്കേഷനുകള്‍ ഇനേബിള്‍ ചെയ്യുക",

--- a/src/i18n/strings/nb_NO.json
+++ b/src/i18n/strings/nb_NO.json
@@ -19,7 +19,6 @@
     "Direct Chat": "Direkte Chat",
     "Directory": "Katalog",
     "Download this file": "Last ned filen",
-    "Enable audible notifications in web client": "Aktiver lyd-varsel i webklient",
     "Enable desktop notifications": "Aktiver skrivebordsvarsler",
     "Enable email notifications": "Aktiver e-postvarsler",
     "Enable notifications for this account": "Aktiver varsler for denne konto",

--- a/src/i18n/strings/nl.json
+++ b/src/i18n/strings/nl.json
@@ -18,7 +18,6 @@
     "Directory": "Kamerlijst",
     "Dismiss": "Afwijzen",
     "Download this file": "Download dit bestand",
-    "Enable audible notifications in web client": "Geluidsmeldingen in de webclient aanzetten",
     "Enable desktop notifications": "Desktopmeldingen aanzetten",
     "Enable email notifications": "E-mailmeldingen aanzetten",
     "Enable notifications for this account": "Meldingen voor dit account aanzetten",

--- a/src/i18n/strings/pl.json
+++ b/src/i18n/strings/pl.json
@@ -32,7 +32,6 @@
     "customServer_text": "Możesz używać opcji serwera niestandardowego do logowania się na inne serwery Matrix, określając inny adres URL serwera domowego.<br/>Pozwala to na wykorzystanie Riot z istniejącym kontem Matrix na innym serwerze domowym.<br/><br/>Można również ustawić niestandardowy serwer tożsamości, ale nie będzie można zapraszać użytkowników adresem e-mail, ani być zaproszonym przez adres e-mailowy.",
     "Delete the room alias %(alias)s and remove %(name)s from the directory?": "Usuń alias %(alias)s i usuń %(name)s z katalogu?",
     "Dismiss": "Zamknij",
-    "Enable audible notifications in web client": "Włącz dźwiękowe powiadomienia w kliencie internetowym",
     "Enable email notifications": "Włącz powiadomienia e-mailowe",
     "Enable notifications for this account": "Włącz powiadomienia na tym koncie",
     "Enable them now": "Włącz je teraz",

--- a/src/i18n/strings/pt.json
+++ b/src/i18n/strings/pt.json
@@ -15,7 +15,6 @@
     "Directory": "Diretório",
     "Dismiss": "Descartar",
     "Download this file": "Transferir este ficheiro",
-    "Enable audible notifications in web client": "Ativar notificações de áudio no cliente web",
     "Enable desktop notifications": "Ativar notificações no desktop",
     "Enable email notifications": "Ativar notificações por e-mail",
     "Enable notifications for this account": "Ativar notificações para esta conta",

--- a/src/i18n/strings/pt_BR.json
+++ b/src/i18n/strings/pt_BR.json
@@ -15,7 +15,6 @@
     "Directory": "Diretório",
     "Dismiss": "Descartar",
     "Download this file": "Baixar este arquivo",
-    "Enable audible notifications in web client": "Ativar notificações de áudio no cliente web",
     "Enable desktop notifications": "Ativar notificações no desktop",
     "Enable email notifications": "Ativar notificações por email",
     "Enable notifications for this account": "Ativar notificações para esta conta",

--- a/src/i18n/strings/ru.json
+++ b/src/i18n/strings/ru.json
@@ -9,7 +9,6 @@
     "Direct Chat": "Прямой чат",
     "Directory": "Каталог",
     "Dismiss": "Отказ",
-    "Enable audible notifications in web client": "Включить звуковые уведомления в веб-клиенте",
     "Enable desktop notifications": "Включить оповещения на рабочем столе",
     "Enable email notifications": "Включить уведомления по email",
     "Enable notifications for this account": "Включить уведомления для этой учетной записи",

--- a/src/i18n/strings/sk.json
+++ b/src/i18n/strings/sk.json
@@ -39,7 +39,6 @@
     "You might have configured them in a client other than Riot. You cannot tune them in Riot but they still apply": "Tieto nastavenia oznámení sa použijú aj napriek tomu, že ich nemôžete meniť cez Riot. Pravdepodobne ste si ich nastavili v inej aplikácii",
     "Enable desktop notifications": "Povoliť oznámenia na pracovnej ploche",
     "Show message in desktop notification": "Zobraziť text správy v oznámení na pracovnej ploche",
-    "Enable audible notifications in web client": "Povoliť zvukové oznámenia vo webovom klientovi",
     "Off": "Zakázané",
     "On": "Povolené",
     "Noisy": "Hlučné",

--- a/src/i18n/strings/sq.json
+++ b/src/i18n/strings/sq.json
@@ -39,7 +39,6 @@
     "You might have configured them in a client other than Riot. You cannot tune them in Riot but they still apply": "Mund t’i keni formësuar në një tjetër klient nga Riot-i. S’mund t’i sintonizoni në Riot, por ata janë ende të vlefshëm",
     "Enable desktop notifications": "Aktivizo njoftime në desktop",
     "Show message in desktop notification": "Shfaq mesazh në njoftim për desktop",
-    "Enable audible notifications in web client": "Aktivizoni njoftime audio te klienti web",
     "Off": "Off",
     "On": "On",
     "Noisy": "I zhurmshëm",

--- a/src/i18n/strings/sr.json
+++ b/src/i18n/strings/sr.json
@@ -39,7 +39,6 @@
     "You might have configured them in a client other than Riot. You cannot tune them in Riot but they still apply": "Можда сте их подесили у неком другом клијенту а не Riot-у. Не можете их преправљати у Riot-у али се и даље примењују",
     "Enable desktop notifications": "Омогући стона обавештења",
     "Show message in desktop notification": "Прикажи поруку у стоном обавештењу",
-    "Enable audible notifications in web client": "Омогући звучна обавештења у веб клијенту",
     "Off": "Искључено",
     "On": "Укључено",
     "Noisy": "Бучно",

--- a/src/i18n/strings/sv.json
+++ b/src/i18n/strings/sv.json
@@ -17,7 +17,6 @@
     "Directory": "Katalog",
     "Dismiss": "Avvisa",
     "Download this file": "Ladda ner filen",
-    "Enable audible notifications in web client": "Sätt på högljudda aviseringar i webbklienten",
     "Enable desktop notifications": "Sätt på skrivbordsaviseringar",
     "Enable email notifications": "Sätt på epostaviseringar",
     "Enable notifications for this account": "Sätt på aviseringar för det här kontot",

--- a/src/i18n/strings/ta.json
+++ b/src/i18n/strings/ta.json
@@ -27,7 +27,6 @@
     "Directory": "அடைவு",
     "Dismiss": "நீக்கு",
     "Download this file": "இந்த கோப்பைத் தரவிறக்கு",
-    "Enable audible notifications in web client": "இணைய வாங்கியில் ஒலி அறிவிப்புகளை ஏதுவாக்கு",
     "Enable desktop notifications": "திரை அறிவிப்புகளை ஏதுவாக்கு",
     "Enable email notifications": "மின்னஞ்சல் அறிவிப்புகளை ஏதுவாக்கு",
     "Enable notifications for this account": "இந்த கணக்கிற்கான அறிவிப்புகளை ஏதுவாக்கு",

--- a/src/i18n/strings/te.json
+++ b/src/i18n/strings/te.json
@@ -33,7 +33,6 @@
     "Directory": "వివరం",
     "Dismiss": "రద్దుచేసే",
     "Download this file": "ఈ దస్త్రం దిగుమతి చేయండి",
-    "Enable audible notifications in web client": "వెబ్ బంట్రౌతు వినిపించే నోటిఫికేషన్లను ప్రారంభించండి",
     "Enable desktop notifications": "రంగస్థల తాఖీదు ప్రారంభించండి",
     "Enable email notifications": "ఇమెయిల్ ప్రకటనలను ప్రారంభించండి",
     "Enable notifications for this account": "ఈ ఖాతా కోసం తాఖీదు ప్రారంభించండి",

--- a/src/i18n/strings/th.json
+++ b/src/i18n/strings/th.json
@@ -84,7 +84,6 @@
     "All messages (noisy)": "ทุกข้อความ (เสียงดัง)",
     "Custom Server Options": "กำหนดเซิร์ฟเวอร์เอง",
     "Directory": "ไดเรกทอรี",
-    "Enable audible notifications in web client": "เปิดใช้งานเสียงแจ้งเตือนบนเว็บไคลเอนต์",
     "Enable desktop notifications": "เปิดใช้งานการแจ้งเตือนบนเดสก์ทอป",
     "Enable email notifications": "เปิดใช้งานการแจ้งเตือนทางอีเมล",
     "Enable notifications for this account": "เปิดใช้งานการแจ้งเตือนสำหรับบัญชีนี้",

--- a/src/i18n/strings/tr.json
+++ b/src/i18n/strings/tr.json
@@ -28,7 +28,6 @@
     "Directory": "Dizin",
     "Dismiss": "Uzaklaştır",
     "Download this file": "Bu dosyayı indir",
-    "Enable audible notifications in web client": "Web istemcisinde sesli bildirimleri etkinleştir",
     "Enable desktop notifications": "Masaüstü bildirimlerini etkinleştir",
     "Enable email notifications": "E-posta bildirimlerini etkinleştir",
     "Enable notifications for this account": "Bu hesap için bildirimleri etkinleştir",

--- a/src/i18n/strings/uk.json
+++ b/src/i18n/strings/uk.json
@@ -27,7 +27,6 @@
     "Directory": "Каталог",
     "Dismiss": "Відхилити",
     "Download this file": "Звантажити цей файл",
-    "Enable audible notifications in web client": "Увімкнути звукові сповіщення у мережевому застосунку",
     "Enable desktop notifications": "Увімкнути сповіщення на стільниці",
     "Enable email notifications": "Увімкнути сповіщення е-поштою",
     "Enable notifications for this account": "Увімкнути сповіщення для цієї обліковки",

--- a/src/i18n/strings/zh_Hans.json
+++ b/src/i18n/strings/zh_Hans.json
@@ -32,7 +32,6 @@
     "Download this file": "下载该文件",
     "Collapse panel": "折叠面板",
     "Direct Chat": "私聊",
-    "Enable audible notifications in web client": "在网页客户端启用音频通知",
     "Enable desktop notifications": "启用桌面通知",
     "Enable email notifications": "启用电子邮件通知",
     "Enable notifications for this account": "为本账号启用通知",

--- a/src/i18n/strings/zh_Hant.json
+++ b/src/i18n/strings/zh_Hant.json
@@ -94,7 +94,6 @@
     "An error occurred whilst saving your email notification preferences.": "在儲存你的電子郵件通知偏好時發生錯誤。",
     "Collecting app version information": "收集應用程式版本資訊",
     "Delete the room alias %(alias)s and remove %(name)s from the directory?": "刪除聊天室別名 %(alias)s 並從目錄移除 %(name)s？",
-    "Enable audible notifications in web client": "在網頁客戶端啟用音訊通知",
     "Enter keywords separated by a comma:": "輸入以逗號隔開的關鍵字：",
     "Error saving email notification preferences": "儲存電子郵件通知偏好設定時出錯",
     "Failed to add tag %(tagName)s to room": "新增標籤 %(tagName)s 到聊天室失敗",


### PR DESCRIPTION
Remove "in web client" from "audible notifications" setting label, since Riot is
also a desktop application.

Fixes vector-im/riot-web#5101

Signed-off-by: Aidan Gauland aidalgol+ghpr@fastmail.net