### PR TITLE
Fix favicon

### DIFF
--- a/scripts/copy-res.js
+++ b/scripts/copy-res.js
@@ -50,7 +50,7 @@ const COPY_LIST = [
     ["res/home.html", "webapp"],
     ["res/home-status.html", "webapp"],
     ["res/home/**", "webapp/home"],
-    ["res/vector-icons/**", "webapp"],
+    ["res/vector-icons/**", "webapp/vector-icons"],
     ["node_modules/matrix-react-sdk/res/{fonts,img,themes}/**", "webapp"],
     ["res/themes/**", "webapp/themes"],
     ["node_modules/emojione/assets/svg/*", "webapp/emojione/svg/"],


### PR DESCRIPTION
In removing 'media' here, it changed the meaning of the copy so
the contents of vector-icons (rather than the dir itself) got
copied to webapp/

Fixes https://github.com/vector-im/riot-web/issues/6571