### PR TITLE
Fix args in the release wrapper script

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -7,6 +7,15 @@
 
 set -e
 
+orig_args=$@
+
+# chomp any args starting with '-' as these need to go
+# through to the rleease script and otherwise we'll get
+# confused about what the version arg is.
+while [[ "$1" == -* ]]; do
+    shift
+done
+
 cd `dirname $0`
 
 for i in matrix-js-sdk matrix-react-sdk
@@ -38,4 +47,4 @@ git commit package.json -m "$tag"
 
 cd ..
 
-exec ./node_modules/matrix-js-sdk/release.sh -z "$@"
+exec ./node_modules/matrix-js-sdk/release.sh -z "$orig_args"

--- a/release.sh
+++ b/release.sh
@@ -10,7 +10,7 @@ set -e
 orig_args=$@
 
 # chomp any args starting with '-' as these need to go
-# through to the rleease script and otherwise we'll get
+# through to the release script and otherwise we'll get
 # confused about what the version arg is.
 while [[ "$1" == -* ]]; do
     shift


### PR DESCRIPTION
It was assuming the version was always $1 which meant there was no
way to pass options (eg. -x to skip changelog generation) through
to the underlying release script without breaking the wrapper
script.