### PR TITLE
Enforce loading babel-polyfill first

### DIFF
--- a/src/vector/index.js
+++ b/src/vector/index.js
@@ -17,18 +17,6 @@ limitations under the License.
 
 'use strict';
 
-// for ES6 stuff like startsWith() that Safari doesn't handle
-// and babel doesn't do by default
-// Note we use this, as well as the babel transform-runtime plugin
-// since transform-runtime does not cover instance methods
-// such as "foobar".includes("foo") which bits of our library
-// code use, but the babel transform-runtime plugin allows the
-// regenerator runtime to be injected early enough in the process
-// (it can't be here as it's too late: the alternative is to put
-// the babel-polyfill as the first 'entry' in the webpack config).
-// https://babeljs.io/docs/plugins/transform-runtime/
-require('babel-polyfill');
-
 // Require common CSS here; this will make webpack process it into bundle.css.
 // Our own CSS (which is themed) is imported via separate webpack entry points
 // in webpack.config.js

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,6 +8,11 @@ if (!og_image_url) og_image_url = 'https://riot.im/app/themes/riot/img/logos/rio
 
 module.exports = {
     entry: {
+        main: [
+            // Load this first to avoid issues where some imports (namely react)
+            // potentially before babel-polyfill.
+            'babel-polyfill',
+        ],
         "bundle": "./src/vector/index.js",
         "indexeddb-worker": "./src/vector/indexeddb-worker.js",
 


### PR DESCRIPTION
This is to avoid loading anything before loading the polyfill, otherwise
we risk loading dependencies (such as React) before it.

This was causing the compatibility page to fail somehow.

See https://github.com/facebook/react/issues/8379

Fixes https://github.com/vector-im/riot-web/issues/6562