### PR TITLE
Hide URL options for e2e blob: URL images

### DIFF
--- a/electron_app/src/webcontents-handler.js
+++ b/electron_app/src/webcontents-handler.js
@@ -35,12 +35,15 @@ function onLinkContextMenu(ev, params) {
     const url = params.linkURL || params.srcURL;
 
     const popupMenu = new Menu();
-    popupMenu.append(new MenuItem({
-        label: url,
-        click() {
-            safeOpenURL(url);
-        },
-    }));
+    // No point trying to open blob: URLs in an external browser: it ain't gonna work.
+    if (!url.startsWith('blob:')) {
+        popupMenu.append(new MenuItem({
+            label: url,
+            click() {
+                safeOpenURL(url);
+            },
+        }));
+    }
 
     if (params.mediaType && params.mediaType === 'image' && !url.startsWith('file://')) {
         popupMenu.append(new MenuItem({
@@ -55,12 +58,15 @@ function onLinkContextMenu(ev, params) {
         }));
     }
 
-    popupMenu.append(new MenuItem({
-        label: 'Copy Link Address',
-        click() {
-            clipboard.writeText(url);
-        },
-    }));
+    // No point offerring to copy a blob: URL either
+    if (!url.startsWith('blob:')) {
+        popupMenu.append(new MenuItem({
+            label: 'Copy Link Address',
+            click() {
+                clipboard.writeText(url);
+            },
+        }));
+    }
     // popup() requires an options object even for no options
     popupMenu.popup({});
     ev.preventDefault();


### PR DESCRIPTION
These won't work outside of the electron app so there is zero point
in trying to open them in an external browser or offerring to copy
them to the clipboard