### PR TITLE
add override for colour of room tile text within memberinfo (unreadable)

### DIFF
--- a/res/themes/status/css/_status.scss
+++ b/res/themes/status/css/_status.scss
@@ -284,3 +284,7 @@ $progressbar-color: #000;
 .mx_RoomSubList_chevron {
     top: 8px ! important;
 }
+
+.mx_MemberInfo .mx_RoomTile_name {
+    color: $primary-fg-color ! important;
+}


### PR DESCRIPTION
### Fixes https://github.com/vector-im/riot-web/issues/5927

Signed-off-by: Michael Telatynski <7t3chguy@gmail.com>