### PR TITLE
js-sdk now requires json-loader because webpack is made of fail

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ First clone and build `matrix-js-sdk`:
 1. `pushd matrix-js-sdk`
 1. `git checkout develop`
 1. `npm install`
-1. `npm install source-map-loader` # because webpack is made of fail (https://github.com/webpack/webpack/issues/1472)
+1. `npm install source-map-loader json-loader` # because webpack is made of fail (https://github.com/webpack/webpack/issues/1472)
 1. `popd`
 
 Then similarly with `matrix-react-sdk`:


### PR DESCRIPTION
since js-sdk uses unhomoglyph which loads JS

Signed-off-by: Michael Telatynski <7t3chguy@gmail.com>