### PR TITLE
Pin sanitize-html to 0.18.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "prop-types": "^15.5.10",
     "react": "^15.6.0",
     "react-dom": "^15.6.0",
-    "sanitize-html": "^1.11.1",
+    "sanitize-html": "1.18.2",
     "ua-parser-js": "^0.7.10",
     "url": "^0.11.0"
   },


### PR DESCRIPTION
Because 0.18.3 is broken (https://github.com/punkave/sanitize-html/issues/241
 / https://github.com/punkave/sanitize-html/issues/242