### PR TITLE
Unpin sanitize-html

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "prop-types": "^15.5.10",
     "react": "^15.6.0",
     "react-dom": "^15.6.0",
-    "sanitize-html": "1.18.2",
+    "sanitize-html": "^1.18.4",
     "ua-parser-js": "^0.7.10",
     "url": "^0.11.0"
   },


### PR DESCRIPTION
1.18.4 is now out which makes it work with webpack again