### PR TITLE
s/DidMount/WillMount/ in MessageComposerInput

### DIFF
--- a/src/vector/index.js
+++ b/src/vector/index.js
@@ -251,7 +251,9 @@ async function loadApp() {
 
     // don't try to redirect to the native apps if we're
     // verifying a 3pid (but after we've loaded the config)
-    const preventRedirect = Boolean(fragparts.params.client_secret);
+    // or if the user is following a deep link
+    // (https://github.com/vector-im/riot-web/issues/7378)
+    const preventRedirect = fragparts.params.client_secret || fragparts.location.length > 0;
 
     if (!preventRedirect) {
         const isIos = /iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream;


### PR DESCRIPTION
Fixes the tests that got broken by https://github.com/matrix-org/matrix-js-sdk/pull/717
because https://github.com/vector-im/riot-web/blob/master/test/app-tests/joining.js#L63
means that although the components get rendered, they never actually end up in the DOM,
so DidMount never gets called.

It's more normal (and symmetrical) to put setup code like this in WillMount since
the corresponding teardown code will be in WillUnmount (since there is no DidUnmount).