### PR TITLE
Stop electron crashing

### DIFF
--- a/src/vector/platform/ElectronPlatform.js
+++ b/src/vector/platform/ElectronPlatform.js
@@ -170,7 +170,7 @@ export default class ElectronPlatform extends VectorBasePlatform {
 
     clearNotification(notif: Notification) {
         // This crashes on windows under certain circumstances: can't find any
-        // workaround othet than not closing notifs.
+        // workaround other than not closing notifs.
         // https://github.com/electron/electron/issues/15251
         // https://github.com/vector-im/riot-web/issues/7512
         if (window.process.platform === 'win32') return;

--- a/src/vector/platform/ElectronPlatform.js
+++ b/src/vector/platform/ElectronPlatform.js
@@ -169,6 +169,11 @@ export default class ElectronPlatform extends VectorBasePlatform {
     }
 
     clearNotification(notif: Notification) {
+        // This crashes on windows under certain circumstances: can't find any
+        // workaround othet than not closing notifs.
+        // https://github.com/electron/electron/issues/15251
+        // https://github.com/vector-im/riot-web/issues/7512
+        if (window.process.platform === 'win32') return;
         notif.close();
     }
 


### PR DESCRIPTION
Workaround temporarily by not closing notifs on win32 as per
comment.

Fixes https://github.com/vector-im/riot-web/issues/7512

NB. This PR is against the release branch