### PR TITLE
Don't set tags on notifications

### DIFF
--- a/src/vector/platform/ElectronPlatform.js
+++ b/src/vector/platform/ElectronPlatform.js
@@ -143,7 +143,6 @@ export default class ElectronPlatform extends VectorBasePlatform {
             {
                 body: msg,
                 icon: avatarUrl,
-                tag: 'vector',
                 silent: true, // we play our own sounds
             },
         );
@@ -169,11 +168,6 @@ export default class ElectronPlatform extends VectorBasePlatform {
     }
 
     clearNotification(notif: Notification) {
-        // This crashes on windows under certain circumstances: can't find any
-        // workaround other than not closing notifs.
-        // https://github.com/electron/electron/issues/15251
-        // https://github.com/vector-im/riot-web/issues/7512
-        if (window.process.platform === 'win32') return;
         notif.close();
     }
 


### PR DESCRIPTION
They are to suppress notifications that don't want to be shown in
addition to each other. This makes no sense for our notifications:
they're each for independent messages. Also settings tags on
notifications makes electron crash on windows when you close the
notif, as per https://github.com/vector-im/riot-web/issues/7512