### PR TITLE
Mock fs, tls, and net to support request in the browser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5061,7 +5061,7 @@
         },
         "finalhandler": {
           "version": "1.1.1",
-          "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
           "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
           "dev": true,
           "requires": {
@@ -5209,6 +5209,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
       "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+    },
+    "fast-extend": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/fast-extend/-/fast-extend-0.0.2.tgz",
+      "integrity": "sha1-9exCz0C5Rg9SGmOH37Ut7u1nHb0=",
+      "dev": true
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
@@ -5410,7 +5416,7 @@
         },
         "fbjs": {
           "version": "0.1.0-alpha.7",
-          "resolved": "http://registry.npmjs.org/fbjs/-/fbjs-0.1.0-alpha.7.tgz",
+          "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.1.0-alpha.7.tgz",
           "integrity": "sha1-rUMIuPIy+zxzYDNJ6nJdHpw5Mjw=",
           "requires": {
             "core-js": "^1.0.0",
@@ -5420,7 +5426,7 @@
         },
         "whatwg-fetch": {
           "version": "0.9.0",
-          "resolved": "http://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-0.9.0.tgz",
+          "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-0.9.0.tgz",
           "integrity": "sha1-DjaExsuZlbQ+/J3wPkw2XZX9nMA="
         }
       }
@@ -5601,6 +5607,12 @@
           }
         }
       }
+    },
+    "fs-monkey": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-0.3.3.tgz",
+      "integrity": "sha512-FNUvuTAJ3CqCQb5ELn+qCbGR/Zllhf2HtwsdAtBi59s1WeCjKMT81fHcSu7dwIskqGVK+MmOrb7VOBlq3/SItw==",
+      "dev": true
     },
     "fs-readdir-recursive": {
       "version": "1.0.0",
@@ -7649,13 +7661,15 @@
               "version": "1.0.0",
               "resolved": false,
               "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "resolved": false,
               "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
               "dev": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -7672,19 +7686,22 @@
               "version": "1.1.0",
               "resolved": false,
               "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
               "resolved": false,
               "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "resolved": false,
               "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -7815,7 +7832,8 @@
               "version": "2.0.3",
               "resolved": false,
               "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -7829,6 +7847,7 @@
               "resolved": false,
               "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
               "dev": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -7845,6 +7864,7 @@
               "resolved": false,
               "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
               "dev": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -7968,7 +7988,8 @@
               "version": "1.0.1",
               "resolved": false,
               "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -7982,6 +8003,7 @@
               "resolved": false,
               "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
               "dev": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -8119,6 +8141,7 @@
               "resolved": false,
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "dev": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -8824,7 +8847,6 @@
         "flux": "2.1.1",
         "focus-trap-react": "^3.0.5",
         "fuse.js": "^2.2.0",
-        "gemini-scrollbar": "github:matrix-org/gemini-scrollbar#b302279810d05319ac5ff1bd34910bff32325c7b",
         "gfm.css": "^1.1.1",
         "glob": "^5.0.14",
         "highlight.js": "^9.13.0",
@@ -8832,7 +8854,6 @@
         "linkifyjs": "^2.1.6",
         "lodash": "^4.13.1",
         "lolex": "2.3.2",
-        "matrix-js-sdk": "github:matrix-org/matrix-js-sdk#5d84db9fb72678af38c50de5eefe4c0b7bd48af1",
         "optimist": "^0.6.1",
         "pako": "^1.0.5",
         "prop-types": "^15.5.8",
@@ -8842,23 +8863,60 @@
         "react-addons-css-transition-group": "15.3.2",
         "react-beautiful-dnd": "^4.0.1",
         "react-dom": "^15.6.0",
-        "react-gemini-scrollbar": "github:matrix-org/react-gemini-scrollbar#5e97aef7e034efc8db1431f4b0efe3b26e249ae9",
         "resize-observer-polyfill": "^1.5.0",
         "sanitize-html": "^1.18.4",
         "slate": "^0.41.2",
         "slate-html-serializer": "^0.6.1",
-        "slate-md-serializer": "github:matrix-org/slate-md-serializer#f7c4ad394f5af34d4c623de7909ce95ab78072d3",
         "slate-react": "^0.18.10",
         "text-encoding-utf-8": "^1.0.1",
         "url": "^0.11.0",
-        "velocity-vector": "github:vector-im/velocity#059e3b2348f1110888d033974d3109fd5a3af00f",
         "whatwg-fetch": "^1.1.1"
       },
       "dependencies": {
+        "gemini-scrollbar": {
+          "version": "github:matrix-org/gemini-scrollbar#b302279810d05319ac5ff1bd34910bff32325c7b",
+          "from": "github:matrix-org/gemini-scrollbar#b302279810d05319ac5ff1bd34910bff32325c7b"
+        },
         "highlight.js": {
           "version": "9.13.0",
           "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.13.0.tgz",
           "integrity": "sha512-2B90kcNnErqRTmzdZw6IPLEC9CdsiIMhj+r8L3LJKRCgtEJ+LY5yzWuQCVnADTI0wwocQinFzaaL/JjTQNqI/g=="
+        },
+        "matrix-js-sdk": {
+          "version": "github:matrix-org/matrix-js-sdk#5d84db9fb72678af38c50de5eefe4c0b7bd48af1",
+          "from": "github:matrix-org/matrix-js-sdk#5d84db9fb72678af38c50de5eefe4c0b7bd48af1",
+          "requires": {
+            "another-json": "^0.2.0",
+            "babel-runtime": "^6.26.0",
+            "bluebird": "^3.5.0",
+            "browser-request": "^0.3.3",
+            "content-type": "^1.0.2",
+            "request": "^2.53.0"
+          }
+        },
+        "react-gemini-scrollbar": {
+          "version": "github:matrix-org/react-gemini-scrollbar#5e97aef7e034efc8db1431f4b0efe3b26e249ae9",
+          "from": "github:matrix-org/react-gemini-scrollbar#5e97aef7e034efc8db1431f4b0efe3b26e249ae9",
+          "requires": {
+            "gemini-scrollbar": "github:matrix-org/gemini-scrollbar#b302279810d05319ac5ff1bd34910bff32325c7b"
+          },
+          "dependencies": {
+            "gemini-scrollbar": {
+              "version": "github:matrix-org/gemini-scrollbar#b302279810d05319ac5ff1bd34910bff32325c7b",
+              "from": "github:matrix-org/gemini-scrollbar#b302279"
+            }
+          }
+        },
+        "slate-md-serializer": {
+          "version": "github:matrix-org/slate-md-serializer#f7c4ad394f5af34d4c623de7909ce95ab78072d3",
+          "from": "github:matrix-org/slate-md-serializer#f7c4ad394f5af34d4c623de7909ce95ab78072d3"
+        },
+        "velocity-vector": {
+          "version": "github:vector-im/velocity#059e3b2348f1110888d033974d3109fd5a3af00f",
+          "from": "github:vector-im/velocity#059e3b2348f1110888d033974d3109fd5a3af00f",
+          "requires": {
+            "jquery": ">= 1.4.3"
+          }
         },
         "whatwg-fetch": {
           "version": "1.1.1",
@@ -8909,9 +8967,19 @@
         "p-is-promise": "^1.1.0"
       }
     },
+    "memfs": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/memfs/-/memfs-2.10.1.tgz",
+      "integrity": "sha512-CXfNuf6TeF4ByYJ/cAxVcR2y58Q511soYd6JhXAJVPYp+9kIbkJZ+FZUw8fQCcNn5+XUNJ38CdjX0gpeUt5ITA==",
+      "dev": true,
+      "requires": {
+        "fast-extend": "0.0.2",
+        "fs-monkey": "^0.3.3"
+      }
+    },
     "memoize-one": {
       "version": "3.1.1",
-      "resolved": "http://registry.npmjs.org/memoize-one/-/memoize-one-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-3.1.1.tgz",
       "integrity": "sha512-YqVh744GsMlZu6xkhGslPSqSurOv6P+kLN2J3ysBZfagLcL5FdRK/0UpgLoL8hwjjEvvAVkjJZyFP+1T6p1vgA=="
     },
     "memory-fs": {
@@ -9710,7 +9778,7 @@
     },
     "p-is-promise": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
       "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4=",
       "dev": true
     },
@@ -11006,19 +11074,6 @@
         "prop-types": "^15.5.10"
       }
     },
-    "react-gemini-scrollbar": {
-      "version": "github:matrix-org/react-gemini-scrollbar#5e97aef7e034efc8db1431f4b0efe3b26e249ae9",
-      "from": "github:matrix-org/react-gemini-scrollbar#5e97aef",
-      "requires": {
-        "gemini-scrollbar": "github:matrix-org/gemini-scrollbar#b302279810d05319ac5ff1bd34910bff32325c7b"
-      },
-      "dependencies": {
-        "gemini-scrollbar": {
-          "version": "github:matrix-org/gemini-scrollbar#b302279810d05319ac5ff1bd34910bff32325c7b",
-          "from": "github:matrix-org/gemini-scrollbar#b302279"
-        }
-      }
-    },
     "react-immutable-proptypes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/react-immutable-proptypes/-/react-immutable-proptypes-2.1.0.tgz",
@@ -11043,7 +11098,7 @@
     },
     "react-redux": {
       "version": "5.0.7",
-      "resolved": "http://registry.npmjs.org/react-redux/-/react-redux-5.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.0.7.tgz",
       "integrity": "sha512-5VI8EV5hdgNgyjfmWzBbdrqUkrVRKlyTKk1sGH3jzM2M2Mhj/seQgPXaz6gVAj2lz/nz688AdTqMO18Lr24Zhg==",
       "requires": {
         "hoist-non-react-statics": "^2.5.0",
@@ -12066,10 +12121,6 @@
         "slate-dev-logger": "^0.1.43",
         "type-of": "^2.0.1"
       }
-    },
-    "slate-md-serializer": {
-      "version": "github:matrix-org/slate-md-serializer#f7c4ad394f5af34d4c623de7909ce95ab78072d3",
-      "from": "github:matrix-org/slate-md-serializer#f7c4ad3"
     },
     "slate-plain-serializer": {
       "version": "0.6.11",
@@ -13711,13 +13762,6 @@
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
       "dev": true
-    },
-    "velocity-vector": {
-      "version": "github:vector-im/velocity#059e3b2348f1110888d033974d3109fd5a3af00f",
-      "from": "github:vector-im/velocity#059e3b2",
-      "requires": {
-        "jquery": ">= 1.4.3"
-      }
     },
     "verror": {
       "version": "1.10.0",
@@ -15739,13 +15783,15 @@
               "version": "1.0.0",
               "resolved": false,
               "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "resolved": false,
               "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
               "dev": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -15768,7 +15814,8 @@
               "version": "0.0.1",
               "resolved": false,
               "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
@@ -15935,6 +15982,7 @@
               "resolved": false,
               "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
               "dev": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -16810,7 +16858,7 @@
     },
     "xmlbuilder": {
       "version": "8.2.2",
-      "resolved": "http://registry.npmjs.org/xmlbuilder/-/xmlbuilder-8.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-8.2.2.tgz",
       "integrity": "sha1-aSSGc0ELS6QuGmE2VR0pIjNap3M=",
       "dev": true
     },

--- a/package.json
+++ b/package.json
@@ -125,6 +125,7 @@
     "karma-webpack": "4.0.0-beta.0",
     "matrix-mock-request": "^1.2.0",
     "matrix-react-test-utils": "^0.2.0",
+    "memfs": "^2.10.1",
     "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",
     "mocha": "^5.2.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -115,7 +115,20 @@ module.exports = {
 
             // same goes for js-sdk
             "matrix-js-sdk": path.resolve('./node_modules/matrix-js-sdk'),
+
+            // To make webpack happy
+            // Related: https://github.com/request/request/issues/1529
+            // (there's no mock available for fs, so we fake a mock by using
+            // an in-memory version of fs)
+            "fs": "memfs",
         },
+    },
+    node: {
+        // Because webpack is made of fail
+        // https://github.com/request/request/issues/1529
+        // Note: 'mock' is the new 'empty'
+        net: 'mock',
+        tls: 'mock'
     },
     externals: {
         // Don't try to bundle electron: leave it as a commonjs dependency


### PR DESCRIPTION
See REACT_PR

fs is mocked using memfs, which needs to be installed at all 3 layers because webpack is silly