### PR TITLE
Fix missing js-sdk logging

### DIFF
--- a/src/vector/index.js
+++ b/src/vector/index.js
@@ -24,6 +24,8 @@ require('gfm.css/gfm.css');
 require('highlight.js/styles/github.css');
 require('draft-js/dist/Draft.css');
 
+import './rageshakesetup';
+
 import React from 'react';
 // add React and ReactPerf to the global namespace, to make them easier to
 // access via the console
@@ -56,8 +58,6 @@ import SdkConfig from "matrix-react-sdk/lib/SdkConfig";
 
 import Olm from 'olm';
 
-import rageshake from "matrix-react-sdk/lib/rageshake/rageshake";
-
 import CallHandler from 'matrix-react-sdk/lib/CallHandler';
 
 import {getVectorConfig} from './getconfig';
@@ -67,22 +67,6 @@ let lastLocationHashSet = null;
 // Disable warnings for now: we use deprecated bluebird functions
 // and need to migrate, but they spam the console with warnings.
 Promise.config({warnings: false});
-
-function initRageshake() {
-    rageshake.init().then(() => {
-        console.log("Initialised rageshake: See https://bugs.chromium.org/p/chromium/issues/detail?id=583193 to fix line numbers on Chrome.");
-
-        window.addEventListener('beforeunload', (e) => {
-            console.log('riot-web closing');
-            // try to flush the logs to indexeddb
-            rageshake.flush();
-        });
-
-        rageshake.cleanup();
-    }, (err) => {
-        console.error("Failed to initialise rageshake: " + err);
-    });
-}
 
 function checkBrowserFeatures(featureList) {
     if (!window.Modernizr) {
@@ -225,7 +209,6 @@ function onTokenLoginCompleted() {
 }
 
 async function loadApp() {
-    initRageshake();
     MatrixClientPeg.setIndexedDbWorkerScript(window.vector_indexeddb_worker_script);
     CallHandler.setConferenceHandler(VectorConferenceHandler);
 

--- a/src/vector/rageshakesetup.js
+++ b/src/vector/rageshakesetup.js
@@ -1,0 +1,46 @@
+/*
+Copyright 2018 New Vector Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+ * Separate file that sets up rageshake logging when imported.
+ * This is necessary so that rageshake logging is set up before
+ * anything else. Webpack puts all import statements at the top
+ * of the file before any code, so imports will always be
+ * evaluated first. Other imports can cause other code to be
+ * evaluated (eg. the loglevel library in js-sdk, which if set
+ * up before rageshake causes some js-sdk logging to be missing
+ * from the rageshake.)
+ */
+
+import rageshake from "matrix-react-sdk/lib/rageshake/rageshake";
+
+function initRageshake() {
+    rageshake.init().then(() => {
+        console.log("Initialised rageshake: See https://bugs.chromium.org/p/chromium/issues/detail?id=583193 to fix line numbers on Chrome.");
+
+        window.addEventListener('beforeunload', (e) => {
+            console.log('riot-web closing');
+            // try to flush the logs to indexeddb
+            rageshake.flush();
+        });
+
+        rageshake.cleanup();
+    }, (err) => {
+        console.error("Failed to initialise rageshake: " + err);
+    });
+}
+
+initRageshake();


### PR DESCRIPTION
Some of the js-sdk logging was going missing due to js-sdk's
loglevel library being initialised before the rageshake logging.

Fix by doing the rageshake setup within an import, as commented.