### PR TITLE
Add a two-stages Dockerfile for building Riot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+# Builder
+FROM node:alpine as builder
+
+COPY . /src
+
+WORKDIR /src
+
+RUN apk add --no-cache git \
+ && npm install \
+ && npm run build
+
+
+# App
+FROM nginx:latest
+
+COPY --from=builder /src/webapp /app
+COPY config.sample.json /app/config.json
+
+RUN rm -rf /usr/share/nginx/html \
+ && ln -s /app /usr/share/nginx/html

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,15 @@
 # Builder
 FROM node:alpine as builder
 
-COPY . /src
+RUN apk add --no-cache git
 
 WORKDIR /src
 
-RUN apk add --no-cache git \
- && npm install \
- && npm run build
+COPY package.json /src/package.json
+RUN npm install
+
+COPY . /src
+RUN npm run build
 
 
 # App


### PR DESCRIPTION
To the best of my knowledge, currently most Docker administrators running Riot Web are using third party images maintained as separate repositories and downloading the tarballs.

This PR provides a fairly simple Dockerfile so the builds can be automatically trigerred for branches and tags on a standard build platform, such transparently providing updates without the need for a third party to maintain a version-specific Dockerfile.

Signed-off-by: Pierre Jaury <pierre@jaury.eu>