### PR TITLE
Link to CONTRIBUTING from JS SDK

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,4 +1,4 @@
 Contributing code to Riot
 =========================
 
-Riot follows the same pattern as https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst.
+Riot follows the same pattern as https://github.com/matrix-org/matrix-js-sdk/blob/master/CONTRIBUTING.rst.


### PR DESCRIPTION
The JS SDK's CONTRIBUTING file is a bit simpler to read. The Synapse version previously used includes mentions of Python lint tools that don't apply here.

Signed-off-by: J. Ryan Stinnett <jryans@gmail.com>