### PR TITLE
Make clear that the Debian package is for desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ Note that Chrome does not allow microphone or webcam access for sites served
 over http (except localhost), so for working VoIP you will need to serve Riot
 over https.
 
-### Installation Steps for Debian Stretch
+### Desktop Installation for Debian Stretch
+
 1. Add the repository to your sources.list using either of the following two options:
   - Directly to sources.list: `echo "deb https://riot.im/packages/debian/ stretch main" | sudo tee -a /etc/apt/sources.list`
   - As a separate entry in sources.list.d: `echo "deb https://riot.im/packages/debian/ stretch main" | sudo tee /etc/apt/sources.list.d/riot.list`


### PR DESCRIPTION
Since this section is just after the "Untar the tarball on your web server" instructions, I had assumed that this was a Debian package for the server. It is not completely uncommon to have packages for web apps, for example phpmyadmin is packaged for Debian.

This makes it clear that this is a desktop app, and will avoid confusion (particularly because riot-web probably won't run on a server, #7918).

Signed-off-by: Remi Rampin <remirampin@gmail.com>