### PR TITLE
Fix the IndexedDB worker

### DIFF
--- a/src/vector/index.html
+++ b/src/vector/index.html
@@ -36,28 +36,10 @@
   <body style="height: 100%;">
     <section id="matrixchat" style="height: 100%;"></section>
     <noscript>Sorry, Riot requires JavaScript to be enabled.</noscript> <!-- TODO: Translate this? -->
-    <% for (var i=0; i < htmlWebpackPlugin.files.js.length; i++) {
-        if (_.endsWith(htmlWebpackPlugin.files.js[i], 'olm.js')) {
-            var array = htmlWebpackPlugin.files.js;
-            htmlWebpackPlugin.files.js.unshift(htmlWebpackPlugin.files.js[i]);
-            htmlWebpackPlugin.files.js.splice(i, 1);
-        }
-       }
-
-       for (var i=0; i < htmlWebpackPlugin.files.js.length; i++) {
-        // Not a particularly graceful way of not putting the indexeddb worker script
-        // into the main page
-        if (_.endsWith(htmlWebpackPlugin.files.js[i], 'indexeddb-worker.js')) {
-            %>
-            <script>
-                window.vector_indexeddb_worker_script = '<%= htmlWebpackPlugin.files.js[i] %>';
-            </script>
-            <%
-            continue;
-        }
-        %>
-        <script src="<%= htmlWebpackPlugin.files.js[i] %>"></script>
-    <% } %>
+    <script>
+        window.vector_indexeddb_worker_script = '<%= htmlWebpackPlugin.files.chunks['indexeddb-worker'].entry %>';
+    </script>
+    <script src="<%= htmlWebpackPlugin.files.chunks['bundle'].entry %>"></script>
     <img src="img/warning.svg" width="24" height="23" style="visibility: hidden; position: absolute; top: 0px; left: 0px;"/>
     <audio id="messageAudio">
         <source src="media/message.ogg" type="audio/ogg" />

--- a/src/vector/index.js
+++ b/src/vector/index.js
@@ -209,6 +209,13 @@ function onTokenLoginCompleted() {
 }
 
 async function loadApp() {
+    if (window.vector_indexeddb_worker_script === undefined) {
+        // If this is missing, something has probably gone wrong with
+        // the bundling. The js-sdk will just fall back to accessing
+        // indexeddb directly with no worker script, but we want to
+        // make sure the indexeddb script is present, so fail hard.
+        throw new Error("Missing indexeddb worker script!");
+    }
     MatrixClientPeg.setIndexedDbWorkerScript(window.vector_indexeddb_worker_script);
     CallHandler.setConferenceHandler(VectorConferenceHandler);
 

--- a/src/vector/indexeddb-worker.js
+++ b/src/vector/indexeddb-worker.js
@@ -18,4 +18,4 @@ import {IndexedDBStoreWorker} from 'matrix-js-sdk/lib/indexeddb-worker.js';
 
 const remoteWorker = new IndexedDBStoreWorker(postMessage);
 
-export const onmessage = remoteWorker.onMessage;
+global.onmessage = remoteWorker.onMessage;


### PR DESCRIPTION
Looks like this was broken in the webpack 4 upgrade due to the
worker script setter and the bundle being re-ordered in index.html.

 * Remove the loop: we only use two scripts now, so import them
   explicitly
 * Remove outdated olm import code.
 * Stop generating a script import for each theme: we were pulling
   in 3 js files that did absolutely nothing.
 * Fix worker 'onmessage' scope (set it as a global rather than
   trying to make it an ES6 module which it isn't).
 * Fail hard if the indexeddb worker script isn't set to avoid
   this happening again.