### PR TITLE
Fix SdkConfig import to use transformed module

### DIFF
--- a/src/vector/rageshakesetup.js
+++ b/src/vector/rageshakesetup.js
@@ -26,7 +26,7 @@ limitations under the License.
  */
 
 import rageshake from "matrix-react-sdk/lib/rageshake/rageshake";
-import SdkConfig from "matrix-react-sdk/src/SdkConfig";
+import SdkConfig from "matrix-react-sdk/lib/SdkConfig";
 
 function initRageshake() {
     rageshake.init().then(() => {


### PR DESCRIPTION
This was originally added in #7755, which pulled in the original source for the
module, breaking ancient browsers without support for classes (#8082).

The issue fixed here is currently live on all riot.im versions, so we may want to merge to other branches as well.