### PR TITLE
Develop branch: Fix SdkConfig import to use transformed module

### DIFF
--- a/src/vector/rageshakesetup.js
+++ b/src/vector/rageshakesetup.js
@@ -26,7 +26,7 @@ limitations under the License.
  */
 
 import rageshake from "matrix-react-sdk/lib/rageshake/rageshake";
-import SdkConfig from "matrix-react-sdk/src/SdkConfig";
+import SdkConfig from "matrix-react-sdk/lib/SdkConfig";
 
 function initRageshake() {
     rageshake.init().then(() => {


### PR DESCRIPTION
This was originally added in #7755, which pulled in the original source for the
module, breaking ancient browsers without support for classes (#8082).

This is the same as #8109, but this one targets `develop`.