### PR TITLE
Correct the copying of e-mail addresses in the electron app

### DIFF
--- a/src/vector/rageshakesetup.js
+++ b/src/vector/rageshakesetup.js
@@ -26,7 +26,7 @@ limitations under the License.
  */
 
 import rageshake from "matrix-react-sdk/lib/rageshake/rageshake";
-import SdkConfig from "matrix-react-sdk/src/SdkConfig";
+import SdkConfig from "matrix-react-sdk/lib/SdkConfig";
 
 function initRageshake() {
     rageshake.init().then(() => {


### PR DESCRIPTION
Fixes #7937 

Changes the labels all the match casing of Chrome.
Fixes a small typo in a comment.

Signed-off-by: Michael Telatynski <7t3chguy@gmail.com>