### PR TITLE
Remove support for team servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,8 +157,6 @@ For a good example, see https://riot.im/develop/config.json
     1. `whitelistedHSUrls`: a list of HS URLs to not redact from the analytics
     1. `whitelistedISUrls`: a list of IS URLs to not redact from the analytics
     1. `siteId`: The Piwik Site ID to use when sending analytics to the Piwik server configured above
-1. `teamServerConfig`, `teamTokenMap`, `referralBaseUrl`: an obsolete precursor to communities
-   with referral tracking; please ignore it.
 1. `welcomeUserId`: the user ID of a bot to invite whenever users register that can give them a tour
 
 

--- a/test/app-tests/loading.js
+++ b/test/app-tests/loading.js
@@ -343,40 +343,6 @@ describe('loading:', function() {
             }).done(done, done);
         });
 
-        it("logs in correctly with a Riot Team Server", function() {
-            sdk.setFetch(httpBackend.fetchFn); // XXX: ought to restore this!
-
-            httpBackend.when('GET', '/pushrules').respond(200, {});
-            httpBackend.when('POST', '/filter').respond(200, { filter_id: 'fid' });
-
-            loadApp({
-                config: {
-                    teamServerConfig: {
-                        teamServerURL: 'http://my_team_server',
-                    },
-                },
-            });
-
-            return Promise.delay(1).then(() => {
-                // we expect a loading spinner while we log into the RTS
-                assertAtLoadingSpinner(matrixChat);
-
-                httpBackend.when('GET', 'my_team_server/login').respond(200, {
-                    team_token: 'nom',
-                });
-                return httpBackend.flush();
-            }).then(() => {
-                return awaitSyncingSpinner(matrixChat);
-            }).then(() => {
-                // we got a sync spinner - let the sync complete
-                return expectAndAwaitSync();
-            }).then(() => {
-                // once the sync completes, we should have a home page
-                ReactTestUtils.findRenderedComponentWithType(
-                    matrixChat, sdk.getComponent('structures.HomePage'));
-            });
-        });
-
         describe('/#/login link:', function() {
             beforeEach(function() {
                 loadApp({


### PR DESCRIPTION
Team servers are an obsolete feature that complicates many critical parts of the app.

Depends on https://github.com/matrix-org/matrix-react-sdk/pull/2511