### PR TITLE
Allow Electron to zoom with CommandOrControl+=

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ for 64 bit Linux:
  1. Follow the instructions in 'Building From Source' above
  2. `node_modules/.bin/build -l --x64`
 
-All electron packages go into `electron/dist/`
+All electron packages go into `electron_app/dist/`
 
 Many thanks to @aviraldg for the initial work on the electron integration.
 

--- a/electron_app/src/vectormenu.js
+++ b/electron_app/src/vectormenu.js
@@ -37,7 +37,6 @@ const template = [
         submenu: [
             { type: 'separator' },
             { role: 'resetzoom' },
-            { role: 'zoomin' },
             { role: 'zoomin', accelerator: 'CommandOrControl+=' },
             { role: 'zoomout' },
             { type: 'separator' },

--- a/electron_app/src/vectormenu.js
+++ b/electron_app/src/vectormenu.js
@@ -38,6 +38,7 @@ const template = [
             { type: 'separator' },
             { role: 'resetzoom' },
             { role: 'zoomin' },
+            { role: 'zoomin', accelerator: 'CommandOrControl+=' },
             { role: 'zoomout' },
             { type: 'separator' },
             { role: 'togglefullscreen' },


### PR DESCRIPTION
Fixes #7721

This creates two menu items which looks bad but [setting the second one to `visible: false` seems to disable it too](https://github.com/electron/electron/issues/15496#issuecomment-460001112). 😡 

![screen shot 2019-02-02 at 3 55 48 pm](https://user-images.githubusercontent.com/5855073/52169741-03951d80-2703-11e9-8f55-8905074d8d1f.png)

Hopefully someone will actually solve https://github.com/electron/electron/issues/15496 upstream