### PR TITLE
Fix order of fetch-develop-deps / npm install

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,12 +68,18 @@ to build.
    is at least v5.x).
 1. Clone the repo: `git clone https://github.com/vector-im/riot-web.git`.
 1. Switch to the riot-web directory: `cd riot-web`.
+1. Install the prerequisites: `npm install`.
 1. If you're using the `develop` branch then it is recommended to set up a proper
    development environment ("Setting up a dev environment" below) however one can
    install the develop versions of the dependencies instead:
    ```bash
    scripts/fetch-develop.deps.sh
    ```
+   Note that running `npm install` will undo the symlinks put in place by
+   `scripts/fetch-develop.deps.sh` so you should run `npm install` first, or
+   run `npm link matrix-js-sdk` and `npm link matrix-react-sdk` after running
+   `npm install`.
+
    Whenever you git pull on riot-web you will also probably need to force an update
    to these dependencies - the simplest way is to re-run the script, but you can also
    manually update and rebuild them:
@@ -93,7 +99,6 @@ to build.
    Or just use https://riot.im/develop - the continuous integration release of the
    develop branch. (Note that we don't reference the develop versions in git directly
    due to https://github.com/npm/npm/issues/3055.)
-1. Install the prerequisites: `npm install`.
 1. Configure the app by copying `config.sample.json` to `config.json` and
    modifying it (see below for details).
 1. `npm run dist` to build a tarball to deploy. Untaring this file will give


### PR DESCRIPTION
It's possible this git fixed in the CI scripts but not the README.
Running `npm install` undoes the npm linking, so this needs to be
run before fetch-develop-deps.