### PR TITLE
Require olm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,9 +144,7 @@
     "source-map-loader": "^0.2.4",
     "webpack": "^4.23.1",
     "webpack-cli": "^3.1.2",
-    "webpack-dev-server": "^3.1.10"
-  },
-  "optionalDependencies": {
+    "webpack-dev-server": "^3.1.10",
     "olm": "https://matrix.org/packages/npm/olm/olm-3.1.0-pre1.tgz"
   },
   "build": {


### PR DESCRIPTION
It's unclear why olm is optional, since it seems to be necessary for the build to succeed. Needed for the NixOS package to build properly.