### PR TITLE
Fix language file path for Jenkins

### DIFF
--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -14,7 +14,11 @@ else
 fi
 
 npm run clean
-npm run build$dev
+# riot-web is at `workspace`.
+# matrix-react-sdk is at `workspace/node_modules/matrix-react-sdk`, but this is
+# symlinked to a repo at `workspace/matrix-react-sdk`.
+# To get from `workspace/matrix-react-sdk/lib` up to the lang file, we use:
+RIOT_LANGUAGES_FILE="../../webapp/i18n/languages.json" npm run build$dev
 
 # include the sample config in the tarball. Arguably this should be done by
 # `npm run build`, but it's just too painful.


### PR DESCRIPTION
Jenkins seems to use a different layout of the repos than other environments.
The sub-projects are cloned inside of the `riot-web` workspace. To account for
this, we need to adjust the Riot language file path.