### PR TITLE
Allow configuration of whether closing window closes or minimizes to tray

### DIFF
--- a/electron_app/package.json
+++ b/electron_app/package.json
@@ -7,6 +7,7 @@
   "author": "New Vector Ltd.",
   "dependencies": {
     "auto-launch": "^5.0.1",
+    "electron-store": "^2.0.0",
     "electron-window-state": "^4.1.0",
     "minimist": "^1.2.0",
     "png-to-ico": "^1.0.2"

--- a/electron_app/src/electron-main.js
+++ b/electron_app/src/electron-main.js
@@ -35,6 +35,7 @@ const updater = require('./updater');
 const { migrateFromOldOrigin } = require('./originMigrator');
 
 const windowStateKeeper = require('electron-window-state');
+const Store = require('electron-store');
 
 // boolean flag set whilst we are doing one-time origin migration
 // We only serve the origin migration script while we're actually
@@ -55,8 +56,11 @@ try {
     // Continue with the defaults (ie. an empty config)
 }
 
+const store = new Store();
+
 let mainWindow = null;
 global.appQuitting = false;
+global.minimizeToTray = store.get('minimizeToTray', true);
 
 
 // handle uncaught errors otherwise it displays
@@ -135,6 +139,12 @@ ipcMain.on('ipcCall', async function(ev, payload) {
             } else {
                 launcher.disable();
             }
+            break;
+        case 'getMinimizeToTrayEnabled':
+            ret = global.minimizeToTray;
+            break;
+        case 'setMinimizeToTrayEnabled':
+            store.set('minimizeToTray', global.minimizeToTray = args[0]);
             break;
         case 'getAppVersion':
             ret = app.getVersion();
@@ -331,7 +341,7 @@ app.on('ready', () => {
         mainWindow = global.mainWindow = null;
     });
     mainWindow.on('close', (e) => {
-        if (!global.appQuitting && (tray.hasTray() || process.platform === 'darwin')) {
+        if (global.minimizeToTray && !global.appQuitting && (tray.hasTray() || process.platform === 'darwin')) {
             // On Mac, closing the window just hides it
             // (this is generally how single-window Mac apps
             // behave, eg. Mail.app)

--- a/src/vector/platform/ElectronPlatform.js
+++ b/src/vector/platform/ElectronPlatform.js
@@ -182,7 +182,7 @@ export default class ElectronPlatform extends VectorBasePlatform {
         return await this._ipcCall('getAutoLaunchEnabled');
     }
 
-    async setAutoLaunchEnabled(enabled: boolean) {
+    async setAutoLaunchEnabled(enabled: boolean): void {
         return await this._ipcCall('setAutoLaunchEnabled', enabled);
     }
 
@@ -194,7 +194,7 @@ export default class ElectronPlatform extends VectorBasePlatform {
         return await this._ipcCall('getMinimizeToTrayEnabled');
     }
 
-    async setMinimizeToTrayEnabled(enabled: boolean) {
+    async setMinimizeToTrayEnabled(enabled: boolean): void {
         return await this._ipcCall('setMinimizeToTrayEnabled', enabled);
     }
 

--- a/src/vector/platform/ElectronPlatform.js
+++ b/src/vector/platform/ElectronPlatform.js
@@ -174,11 +174,11 @@ export default class ElectronPlatform extends VectorBasePlatform {
         return await this._ipcCall('getAppVersion');
     }
 
-    supportsAutoLaunch() {
+    supportsAutoLaunch(): boolean {
         return true;
     }
 
-    async getAutoLaunchEnabled() {
+    async getAutoLaunchEnabled(): boolean {
         return await this._ipcCall('getAutoLaunchEnabled');
     }
 
@@ -186,11 +186,11 @@ export default class ElectronPlatform extends VectorBasePlatform {
         return await this._ipcCall('setAutoLaunchEnabled', enabled);
     }
 
-    supportsMinimizeToTray() {
+    supportsMinimizeToTray(): boolean {
         return true;
     }
 
-    async getMinimizeToTrayEnabled() {
+    async getMinimizeToTrayEnabled(): boolean {
         return await this._ipcCall('getMinimizeToTrayEnabled');
     }
 

--- a/src/vector/platform/ElectronPlatform.js
+++ b/src/vector/platform/ElectronPlatform.js
@@ -182,8 +182,20 @@ export default class ElectronPlatform extends VectorBasePlatform {
         return await this._ipcCall('getAutoLaunchEnabled');
     }
 
-    async setAutoLaunchEnabled(enabled) {
+    async setAutoLaunchEnabled(enabled: boolean) {
         return await this._ipcCall('setAutoLaunchEnabled', enabled);
+    }
+
+    supportsMinimizeToTray() {
+        return true;
+    }
+
+    async getMinimizeToTrayEnabled() {
+        return await this._ipcCall('getMinimizeToTrayEnabled');
+    }
+
+    async setMinimizeToTrayEnabled(enabled: boolean) {
+        return await this._ipcCall('setMinimizeToTrayEnabled', enabled);
     }
 
     async canSelfUpdate(): boolean {

--- a/src/vector/platform/VectorBasePlatform.js
+++ b/src/vector/platform/VectorBasePlatform.js
@@ -88,19 +88,6 @@ export default class VectorBasePlatform extends BasePlatform {
         this._updateFavicon();
     }
 
-    supportsAutoLaunch() {
-        return false;
-    }
-
-    // XXX: Surely this should be a setting like any other?
-    async getAutoLaunchEnabled() {
-        return false;
-    }
-
-    async setAutoLaunchEnabled(enabled) {
-        throw new Error("Unimplemented");
-    }
-
     /**
      * Begin update polling, if applicable
      */


### PR DESCRIPTION
Also moves the Autolaunch platform stuff into the BasePlatform otherwise Preferences Settings would crash given a non-VectorBasePlatform Platform.

![image](https://user-images.githubusercontent.com/2403652/53294615-ba0b9000-37e1-11e9-97ef-9170fdd4eb47.png)

Depends on https://github.com/matrix-org/matrix-react-sdk/pull/2688
Fixes part of https://github.com/vector-im/riot-web/issues/8904

Signed-off-by: Michael Telatynski <7t3chguy@gmail.com>