### PR TITLE
Add support for localConfig at $appData/config.json.

### DIFF
--- a/electron_app/src/electron-main.js
+++ b/electron_app/src/electron-main.js
@@ -56,7 +56,15 @@ try {
     // Continue with the defaults (ie. an empty config)
 }
 
-const store = new Store();
+try {
+    // Load local config and use it to override values from the one baked with the build
+    const localConfig = require(path.join(app.getPath('userData'), 'config.json'));
+    vectorConfig = Object.assign(vectorConfig, localConfig);
+} catch (e) {
+    // Could not load local config, this is expected in most cases.
+}
+
+const store = new Store({ name: "electron-config" });
 
 let mainWindow = null;
 global.appQuitting = false;


### PR DESCRIPTION
Supports an override config at:
```
%APPDATA%\Riot on Windows
$XDG_CONFIG_HOME/Riot or ~/.config/Riot on Linux
~/Library/Application Support/Riot on macOS
```
(or replace `Riot` with `Riot-$PROFILE` if you specify a `--profile`)

Moves electron-config to $appData/electron-config.json which will affect _very_ few users as its Electron only and hasn't made it into master yet.

Fixes https://github.com/vector-im/riot-web/issues/8949

Signed-off-by: Michael Telatynski <7t3chguy@gmail.com>