### PR TITLE
set chrome path for travis CI explicitly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,5 +24,5 @@ install:
     # commit.
     - npm install && scripts/fetch-develop.deps.sh --depth 1
 script:
-    - npm run test
+    - CHROME_BIN='/usr/bin/google-chrome-stable' npm run test
     - npm run lint


### PR DESCRIPTION
karma seems to be giving priority to a location where an old version is installed.

In react-sdk done as part of https://github.com/matrix-org/matrix-react-sdk/pull/2676