### PR TITLE
Change olm dependency to normal dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7228,7 +7228,7 @@
     },
     "got": {
       "version": "6.7.1",
-      "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
+      "resolved": "http://registry.npmjs.org/got/-/got-6.7.1.tgz",
       "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
       "dev": true,
       "requires": {
@@ -7277,9 +7277,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "6.9.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.9.2.tgz",
-          "integrity": "sha512-4UFy0/LgDo7Oa/+wOAlj44tp9K78u38E5/359eSrqEp1Z5PdVfimCcs7SluXMP755RUQu6d2b4AvF0R1C9RZjg==",
+          "version": "6.10.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
+          "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
           "requires": {
             "fast-deep-equal": "^2.0.1",
             "fast-json-stable-stringify": "^2.0.0",
@@ -9048,27 +9048,27 @@
       },
       "dependencies": {
         "react": {
-          "version": "16.8.3",
-          "resolved": "https://registry.npmjs.org/react/-/react-16.8.3.tgz",
-          "integrity": "sha512-3UoSIsEq8yTJuSu0luO1QQWYbgGEILm+eJl2QN/VLDi7hL+EN18M3q3oVZwmVzzBJ3DkM7RMdRwBmZZ+b4IzSA==",
+          "version": "16.8.4",
+          "resolved": "https://registry.npmjs.org/react/-/react-16.8.4.tgz",
+          "integrity": "sha512-0GQ6gFXfUH7aZcjGVymlPOASTuSjlQL4ZtVC5YKH+3JL6bBLCVO21DknzmaPlI90LN253ojj02nsapy+j7wIjg==",
           "optional": true,
           "requires": {
             "loose-envify": "^1.1.0",
             "object-assign": "^4.1.1",
             "prop-types": "^15.6.2",
-            "scheduler": "^0.13.3"
+            "scheduler": "^0.13.4"
           }
         },
         "react-dom": {
-          "version": "16.8.3",
-          "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.8.3.tgz",
-          "integrity": "sha512-ttMem9yJL4/lpItZAQ2NTFAbV7frotHk5DZEHXUOws2rMmrsvh1Na7ThGT0dTzUIl6pqTOi5tYREfL8AEna3lA==",
+          "version": "16.8.4",
+          "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.8.4.tgz",
+          "integrity": "sha512-Ob2wK7XG2tUDt7ps7LtLzGYYB6DXMCLj0G5fO6WeEICtT4/HdpOi7W/xLzZnR6RCG1tYza60nMdqtxzA8FaPJQ==",
           "optional": true,
           "requires": {
             "loose-envify": "^1.1.0",
             "object-assign": "^4.1.1",
             "prop-types": "^15.6.2",
-            "scheduler": "^0.13.3"
+            "scheduler": "^0.13.4"
           }
         }
       }
@@ -9320,9 +9320,9 @@
       "dev": true
     },
     "matrix-js-sdk": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/matrix-js-sdk/-/matrix-js-sdk-1.0.0.tgz",
-      "integrity": "sha512-VeLAtD8qC83bUg2Yp4rdngDkO653gXK5Xr4/L7ny75FRHG09y5ps8Vm8Q08FV0Mr3vSPfO9h92R5m5oQ5AwB9g==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/matrix-js-sdk/-/matrix-js-sdk-1.0.1.tgz",
+      "integrity": "sha512-+ErnXHfkxOoRHUYbY/R+2ZHvPKdPCx/eoYjb2Oy7L9pBqCNllI0WRVsro6oqRJQs0krVP8blyIjWOJynWSw96g==",
       "requires": {
         "another-json": "^0.2.0",
         "babel-runtime": "^6.26.0",
@@ -9348,9 +9348,9 @@
       }
     },
     "matrix-react-sdk": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/matrix-react-sdk/-/matrix-react-sdk-1.0.1.tgz",
-      "integrity": "sha512-FTT74tXoeJPhH/P+Sk5ju50lHyABi0ozrOGJB3+L/uS2qc0OexyBlrEW+QBGbK+nXVosdAEDFQkdeUwDa8svEw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/matrix-react-sdk/-/matrix-react-sdk-1.0.3.tgz",
+      "integrity": "sha512-Igc9ChLpRbN0E/bwA3HMhiYo2c21RA7dQ+eoZ9XEN6vh87ZJz0rUidqmAdvgZQycxW1lZWQ8Aj7/kefHeRswDA==",
       "requires": {
         "babel-plugin-syntax-dynamic-import": "^6.18.0",
         "babel-runtime": "^6.26.0",
@@ -9370,13 +9370,13 @@
         "gemini-scrollbar": "github:matrix-org/gemini-scrollbar#b302279810d05319ac5ff1bd34910bff32325c7b",
         "gfm.css": "^1.1.1",
         "glob": "^5.0.14",
-        "highlight.js": "^9.13.0",
+        "highlight.js": "9.14.2",
         "is-ip": "^2.0.0",
         "isomorphic-fetch": "^2.2.1",
         "linkifyjs": "^2.1.6",
         "lodash": "^4.13.1",
         "lolex": "2.3.2",
-        "matrix-js-sdk": "1.0.0",
+        "matrix-js-sdk": "1.0.1",
         "optimist": "^0.6.1",
         "pako": "^1.0.5",
         "prop-types": "^15.5.8",
@@ -9400,6 +9400,11 @@
         "zxcvbn": "^4.4.2"
       },
       "dependencies": {
+        "highlight.js": {
+          "version": "9.14.2",
+          "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.14.2.tgz",
+          "integrity": "sha512-Nc6YNECYpxyJABGYJAyw7dBAYbXEuIzwzkqoJnwbc1nIpCiN+3ioYf0XrBnLiyyG0JLuJhpPtt2iTSbXiKLoyA=="
+        },
         "whatwg-fetch": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-1.1.1.tgz",
@@ -10090,10 +10095,8 @@
       "dev": true
     },
     "olm": {
-      "version": "3.1.0-pre1",
-      "resolved": "https://matrix.org/packages/npm/olm/olm-3.1.0-pre1.tgz",
-      "integrity": "sha512-buQmmmZlpTYxj9p/U/Jn9QIVdyaoOE5Hq7/K9MPDjeyxHbnOfv40NxeriCUIH+sQdy4LFnHYDoXyyjicT9tR6g==",
-      "optional": true
+      "version": "https://matrix.org/packages/npm/olm/olm-3.1.0-pre1.tgz",
+      "integrity": "sha512-buQmmmZlpTYxj9p/U/Jn9QIVdyaoOE5Hq7/K9MPDjeyxHbnOfv40NxeriCUIH+sQdy4LFnHYDoXyyjicT9tR6g=="
     },
     "on-finished": {
       "version": "2.3.0",
@@ -11441,9 +11444,9 @@
       "integrity": "sha1-Aj1vObsVyXwHHp5g0A0TbqxfoLQ="
     },
     "react-is": {
-      "version": "16.8.3",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.3.tgz",
-      "integrity": "sha512-Y4rC1ZJmsxxkkPuMLwvKvlL1Zfpbcu+Bf4ZigkHup3v9EfdYhAlWAaVyA19olXq2o2mGn0w+dFKvk3pVVlYcIA=="
+      "version": "16.8.4",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.4.tgz",
+      "integrity": "sha512-PVadd+WaUDOAciICm/J1waJaSvgq+4rHE/K70j0PFqKhkTBsPv/82UGQJNXAngz1fOQLLxI6z1sEDmJDQhCTAA=="
     },
     "react-lifecycles-compat": {
       "version": "3.0.4",
@@ -12370,9 +12373,9 @@
       "dev": true
     },
     "scheduler": {
-      "version": "0.13.3",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.3.tgz",
-      "integrity": "sha512-UxN5QRYWtpR1egNWzJcVLk8jlegxAugswQc984lD3kU7NuobsO37/sRfbpTdBjtnD5TBNFA2Q2oLV5+UmPSmEQ==",
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.4.tgz",
+      "integrity": "sha512-cvSOlRPxOHs5dAhP9yiS/6IDmVAVxmk33f0CtTJRkmUWcb1Us+t7b1wqdzoC0REw2muC9V5f1L/w5R5uKGaepA==",
       "optional": true,
       "requires": {
         "loose-envify": "^1.1.0",
@@ -15221,7 +15224,7 @@
     },
     "xmlbuilder": {
       "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "resolved": "http://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
       "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
       "dev": true
     },

--- a/package.json
+++ b/package.json
@@ -148,7 +148,6 @@
     "webpack-cli": "^3.1.2",
     "webpack-dev-server": "^3.1.10"
   },
-  "optionalDependencies": {},
   "build": {
     "appId": "im.riot.app",
     "electronVersion": "4.0.6",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "matrix-js-sdk": "1.0.1",
     "matrix-react-sdk": "1.0.3",
     "modernizr": "^3.6.0",
+    "olm": "https://matrix.org/packages/npm/olm/olm-3.1.0-pre1.tgz",
     "prop-types": "^15.6.2",
     "react": "^15.6.0",
     "react-dom": "^15.6.0",
@@ -147,9 +148,7 @@
     "webpack-cli": "^3.1.2",
     "webpack-dev-server": "^3.1.10"
   },
-  "optionalDependencies": {
-    "olm": "https://matrix.org/packages/npm/olm/olm-3.1.0-pre1.tgz"
-  },
+  "optionalDependencies": {},
   "build": {
     "appId": "im.riot.app",
     "electronVersion": "4.0.6",

--- a/scripts/jenkins.sh
+++ b/scripts/jenkins.sh
@@ -10,9 +10,6 @@ set -x
 
 npm install
 
-# apparently npm 3.10.3 on node 6.4.0 doesn't upgrade #develop target with npm install unless explicitly asked.
-npm install olm
-
 # check out corresponding branches of dependencies.
 #
 # clone the deps with depth 1: we know we will only ever need that one


### PR DESCRIPTION
It would be nice if it were actually an optional dependency and you
could just not install olm and get a Riot without olm, but you can't:
what you get is a broken Riot, so having it as an optional dep isn't
helping anyone.

Also whatever other package-lock changes npm has decided are
necessary today.