### PR TITLE
Use modern Yarn version on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,9 @@ node_js:
     - 10
 addons:
     chrome: stable
+before_install:
+    - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.13.0
+    - export PATH=$HOME/.yarn/bin:$PATH
 install:
     # clone the deps with depth 1: we know we will only ever need that one
     # commit.


### PR DESCRIPTION
Travis CI uses a quite old version of Yarn by default. This adds Yarn's
recommended incantation for using the latest stable version.

Part of https://github.com/vector-im/riot-web/issues/9150