### PR TITLE
Update Electron help menu link

### DIFF
--- a/electron_app/src/vectormenu.js
+++ b/electron_app/src/vectormenu.js
@@ -57,8 +57,8 @@ const template = [
         role: 'help',
         submenu: [
             {
-                label: 'riot.im',
-                click() { shell.openExternal('https://riot.im/'); },
+                label: 'Riot Help',
+                click() { shell.openExternal('https://about.riot.im/help'); },
             },
         ],
     },


### PR DESCRIPTION
Fixes #8945

Should there also be a second menu item that links to the matrix.org FAQ?