### PR TITLE
Remove node 8.x from the build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,10 @@ node_js:
     # Current status of node versions: https://github.com/nodejs/LTS/
     # We don't work with node 6 because it doesn't support package-lock
     # files which we need to avoid the broken version of base-x
-    - 8
+    #
+    # Our minimum supported version is Node 10.
     - 10
+    - 11
 addons:
     chrome: stable
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,6 @@ node_js:
     # make sure we work with a range of node versions.
     #
     # Current status of node versions: https://github.com/nodejs/LTS/
-    # We don't work with node 6 because it doesn't support package-lock
-    # files which we need to avoid the broken version of base-x
-    #
     # Our minimum supported version is Node 10.
     - 10
     - 11


### PR DESCRIPTION
We don't support Node 8 anymore. Also the build is broken.