### PR TITLE
Use `on_logged_in` action in tests

### DIFF
--- a/test/app-tests/loading.js
+++ b/test/app-tests/loading.js
@@ -307,8 +307,8 @@ describe('loading:', function() {
 
             loadApp();
 
-            return awaitSyncingSpinner(matrixChat).then(() => {
-                // we got a sync spinner - let the sync complete
+            return awaitLoggedIn(matrixChat).then(() => {
+                // we are logged in - let the sync complete
                 return expectAndAwaitSync();
             }).then(() => {
                 // once the sync completes, we should have a room view
@@ -327,8 +327,8 @@ describe('loading:', function() {
 
             loadApp();
 
-            return awaitSyncingSpinner(matrixChat).then(() => {
-                // we got a sync spinner - let the sync complete
+            return awaitLoggedIn(matrixChat).then(() => {
+                // we are logged in - let the sync complete
                 return expectAndAwaitSync();
             }).then(() => {
                 // once the sync completes, we should have a home page
@@ -347,8 +347,8 @@ describe('loading:', function() {
                 uriFragment: "#/room/!room:id",
             });
 
-            return awaitSyncingSpinner(matrixChat).then(() => {
-                // we got a sync spinner - let the sync complete
+            return awaitLoggedIn(matrixChat).then(() => {
+                // we are logged in - let the sync complete
                 return expectAndAwaitSync();
             }).then(() => {
                 // once the sync completes, we should have a room view
@@ -417,9 +417,9 @@ describe('loading:', function() {
 
                 return httpBackend.flush();
             }).then(() => {
-                return awaitSyncingSpinner(matrixChat);
+                return awaitLoggedIn(matrixChat);
             }).then(() => {
-                // we got a sync spinner - let the sync complete
+                // we are logged in - let the sync complete
                 return expectAndAwaitSync({isGuest: true});
             }).then(() => {
                 // once the sync completes, we should have a welcome page
@@ -448,7 +448,7 @@ describe('loading:', function() {
 
                 return httpBackend.flush();
             }).then(() => {
-                return awaitSyncingSpinner(matrixChat);
+                return awaitLoggedIn(matrixChat);
             }).then(() => {
                 return expectAndAwaitSync({isGuest: true});
             }).then((req) => {
@@ -482,7 +482,7 @@ describe('loading:', function() {
 
                 return httpBackend.flush();
             }).then(() => {
-                return awaitSyncingSpinner(matrixChat);
+                return awaitLoggedIn(matrixChat);
             }).then(() => {
                 return expectAndAwaitSync({isGuest: true});
             }).then(() => {
@@ -507,7 +507,7 @@ describe('loading:', function() {
                 });
 
                 return httpBackend.flush().then(() => {
-                    return awaitSyncingSpinner(matrixChat);
+                    return awaitLoggedIn(matrixChat);
                 }).then(() => {
                     // we got a sync spinner - let the sync complete
                     return expectAndAwaitSync();
@@ -654,33 +654,22 @@ function assertAtLoadingSpinner(matrixChat) {
     expect(domComponent.children.length).toEqual(1);
 }
 
-// we've got login creds, and are waiting for the sync to finish.
-// the page includes a logout link.
-function awaitSyncingSpinner(matrixChat, retryLimit, retryCount) {
-    if (retryLimit === undefined) {
-        retryLimit = 10;
+function awaitLoggedIn(matrixChat) {
+    if (matrixChat.state.view === VIEWS.LOGGED_IN) {
+        return Promise.resolve();
     }
-    if (retryCount === undefined) {
-        retryCount = 0;
-    }
-
-    if (matrixChat.state.view === VIEWS.LOADING ||
-            matrixChat.state.view === VIEWS.LOGGING_IN) {
-        console.log(Date.now() + " Awaiting sync spinner: still loading.");
-        if (retryCount >= retryLimit) {
-            throw new Error("MatrixChat still not loaded after " +
-                            retryCount + " tries");
-        }
-        // loading can take quite a long time, because we delete the
-        // indexedDB store.
-        return Promise.delay(5).then(() => {
-            return awaitSyncingSpinner(matrixChat, retryLimit, retryCount + 1);
-        });
-    }
-
-    console.log(Date.now() + " Awaiting sync spinner: load complete.");
-
-    return Promise.resolve();
+    return new Promise(resolve => {
+        const onAction = ({ action }) => {
+            if (action !== "on_logged_in") {
+                return;
+            }
+            console.log(Date.now() + ": Received on_logged_in action");
+            dis.unregister(dispatcherRef);
+            resolve();
+        };
+        const dispatcherRef = dis.register(onAction);
+        console.log(Date.now() + ": Waiting for on_logged_in action");
+    });
 }
 
 function awaitRoomView(matrixChat, retryLimit, retryCount) {

--- a/test/app-tests/loading.js
+++ b/test/app-tests/loading.js
@@ -683,17 +683,6 @@ function awaitSyncingSpinner(matrixChat, retryLimit, retryCount) {
     return Promise.resolve();
 }
 
-function assertAtSyncingSpinner(matrixChat) {
-    const domComponent = ReactDOM.findDOMNode(matrixChat);
-    expect(domComponent.className).toEqual("mx_MatrixChat_splash");
-
-    ReactTestUtils.findRenderedComponentWithType(
-        matrixChat, sdk.getComponent('elements.Spinner'));
-    const logoutLink = ReactTestUtils.findRenderedDOMComponentWithTag(
-        matrixChat, 'a');
-    expect(logoutLink.text).toEqual("Logout");
-}
-
 function awaitRoomView(matrixChat, retryLimit, retryCount) {
     if (retryLimit === undefined) {
         retryLimit = 5;


### PR DESCRIPTION
This changes the way tests wait for login to complete from a timer-based system
(which can cause intermittent failures) to an action-based system. The lifecycle
code dispatches the action `on_logged_in` when login completes which we can wait
for in the tests as a much better indication that work is done.

Required for https://github.com/matrix-org/matrix-react-sdk/pull/2826
Part of https://github.com/vector-im/riot-web/issues/9271