### PR TITLE
Configure auth footer links through Riot config

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ For a good example, see https://riot.im/develop/config.json.
        during authentication flows
     1. `authHeaderLogoUrl`: An logo image that is shown in the header during
        authentication flows
+    1. `authFooterLinks`: a list of links to show in the authentication page footer:
+      `[{"text": "Link text", "url": "https://link.target"}, {"text": "Other link", ...}]`
 1. `integrations_ui_url`: URL to the web interface for the integrations server. The integrations
    server is not Riot and normally not your homeserver either. The integration server settings
    may be left blank to disable integrations.

--- a/src/components/views/auth/VectorAuthFooter.js
+++ b/src/components/views/auth/VectorAuthFooter.js
@@ -18,6 +18,8 @@ limitations under the License.
 'use strict';
 
 const React = require('react');
+import SdkConfig from 'matrix-react-sdk/lib/SdkConfig';
+
 import { _t } from 'matrix-react-sdk/lib/languageHandler';
 
 module.exports = React.createClass({
@@ -27,11 +29,27 @@ module.exports = React.createClass({
     },
 
     render: function() {
+        const brandingConfig = SdkConfig.get().branding;
+        let links = [
+            {"text": "blog", "url": "https://medium.com/@RiotChat"},
+            {"text": "twitter", "url": "https://twitter.com/@RiotChat"},
+            {"text": "github", "url": "https://github.com/vector-im/riot-web"},
+        ];
+
+        if (brandingConfig && brandingConfig.authFooterLinks) {
+            links = brandingConfig.authFooterLinks;
+        }
+
+        const authFooterLinks = [];
+        for (const linkEntry of links) {
+            authFooterLinks.push(
+                <a href={linkEntry.url} target="_blank" rel="noopener">{linkEntry.text}</a>,
+            );
+        }
+
         return (
             <div className="mx_AuthFooter">
-                <a href="https://medium.com/@RiotChat" target="_blank" rel="noopener">blog</a>
-                <a href="https://twitter.com/@RiotChat" target="_blank" rel="noopener">twitter</a>
-                <a href="https://github.com/vector-im/riot-web" target="_blank" rel="noopener">github</a>
+                {authFooterLinks}
                 <a href="https://matrix.org" target="_blank" rel="noopener">{ _t('powered by Matrix') }</a>
             </div>
         );


### PR DESCRIPTION
Our organization needs a imprint and privacy statement right on the login page, and some links to organization pages as well.

I've added a possibility to customize those links through the `config.json`:
``` python
    "branding": {
        # this is already upstream:
        "welcomeBackgroundUrl": "themes/org/bg.jpg",
        "authHeaderLogoUrl": "themes/org/orglogo.svg",

        # these are now added by this pull request:
        "authFooterLinks": [
            {"text": "Our Organization", "url": "https://best-org-ever.edu"},
            {"text": "Some subdepartment", "url": "https://subdepartment.best-org-ever.edu"},
            {"text": "Impressum", "url": "/legal/impressum.html"},
            {"text": "Datenschutz", "url": "/legal/datenschutz.html"},
            {"text": "github", "url": "https://github.com/vector-im/riot-web"}
        ]
    },
```

Fixes #9127.