### PR TITLE
Expire mobile guide cookie after 24 hours

### DIFF
--- a/src/vector/mobile_guide/index.js
+++ b/src/vector/mobile_guide/index.js
@@ -1,7 +1,8 @@
 import {getVectorConfig} from '../getconfig';
 
 function onBackToRiotClick() {
-    document.cookie = 'mobile_redirect_to_guide=false;path=/';
+    // Cookie should expire in 24 hours
+    document.cookie = 'mobile_redirect_to_guide=false;path=/;max-age=86400';
     window.location.href = '../';
 }
 


### PR DESCRIPTION
See https://github.com/vector-im/riot-web/issues/9360

This is to prevent it from always working. Cookies without an expiration are supposed to expire at the end of the session, however the nature of mobile browsers means that the session is unlikely to ever end.