### PR TITLE
Fix autolaunch setting appearing toggled off

### DIFF
--- a/electron_app/src/electron-main.js
+++ b/electron_app/src/electron-main.js
@@ -139,7 +139,7 @@ ipcMain.on('ipcCall', async function(ev, payload) {
             ret = autoUpdater.getFeedURL();
             break;
         case 'getAutoLaunchEnabled':
-            ret = launcher.isEnabled;
+            ret = await launcher.isEnabled();
             break;
         case 'setAutoLaunchEnabled':
             if (args[0]) {


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/9123

The value used here is a function which returns a promise, not a flag.