### PR TITLE
Add expiration to mobile guide cookie

### DIFF
--- a/src/vector/index.js
+++ b/src/vector/index.js
@@ -272,7 +272,7 @@ async function loadApp() {
         const isIos = /iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream;
         const isAndroid = /Android/.test(navigator.userAgent);
         if (isIos || isAndroid) {
-            if (!document.cookie.split(';').some((c) => c.startsWith('mobile_redirect_to_guide'))) {
+            if (document.cookie.indexOf("riot_mobile_redirect_to_guide=false") === -1) {
                 window.location = "mobile_guide/";
                 return;
             }

--- a/src/vector/mobile_guide/index.js
+++ b/src/vector/mobile_guide/index.js
@@ -2,7 +2,7 @@ import {getVectorConfig} from '../getconfig';
 
 function onBackToRiotClick() {
     // Cookie should expire in 4 hours
-    document.cookie = 'mobile_redirect_to_guide=false;path=/;max-age=14400';
+    document.cookie = 'riot_mobile_redirect_to_guide=false;path=/;max-age=14400';
     window.location.href = '../';
 }
 

--- a/src/vector/mobile_guide/index.js
+++ b/src/vector/mobile_guide/index.js
@@ -1,7 +1,8 @@
 import {getVectorConfig} from '../getconfig';
 
 function onBackToRiotClick() {
-    document.cookie = 'mobile_redirect_to_guide=false;path=/';
+    // Cookie should expire in 24 hours
+    document.cookie = 'mobile_redirect_to_guide=false;path=/;max-age=86400';
     window.location.href = '../';
 }
 

--- a/src/vector/mobile_guide/index.js
+++ b/src/vector/mobile_guide/index.js
@@ -1,8 +1,8 @@
 import {getVectorConfig} from '../getconfig';
 
 function onBackToRiotClick() {
-    // Cookie should expire in 24 hours
-    document.cookie = 'mobile_redirect_to_guide=false;path=/;max-age=86400';
+    // Cookie should expire in 4 hours
+    document.cookie = 'mobile_redirect_to_guide=false;path=/;max-age=14400';
     window.location.href = '../';
 }
 


### PR DESCRIPTION
See #9360

This is to prevent it from always working. Cookies without an expiration are supposed to expire at the end of the session, however the nature of mobile browsers means that the session is unlikely to ever end.