### PR TITLE
Remove vector-electron-desktop from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,6 @@ All electron packages go into `electron_app/dist/`
 Many thanks to @aviraldg for the initial work on the electron integration.
 
 Other options for running as a desktop app:
- * https://github.com/krisak/vector-electron-desktop
  * @asdf:matrix.org points out that you can use nativefier and it just works(tm)
 
 ```bash


### PR DESCRIPTION
The repo (https://github.com/iskrisis/vector-electron-desktop) very clearly states not to use it anymore.