### PR TITLE
Add support for custom profile directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,8 @@ Desktop app configuration
 
 To run multiple instances of the desktop app for different accounts, you can launch the executable with the `--profile` argument followed by a unique identifier, e.g `riot-web --profile Work` for it to run a separate profile and not interfere with the default one.
 
+Alternatively, a custom location for the profile data can be specified using the `--profile-dir` flag followed by the desired path.
+
 To change the config.json for the desktop app, create a config file which will be used to override values in the config which ships in the package:
 + `%APPDATA%\$NAME\config.json` on Windows
 + `$XDG_CONFIG_HOME\$NAME\config.json` or `~/.config/$NAME/config.json` on Linux

--- a/electron_app/src/electron-main.js
+++ b/electron_app/src/electron-main.js
@@ -42,7 +42,9 @@ const Store = require('electron-store');
 // migrating to mitigate any risk of it being used maliciously.
 let migratingOrigin = false;
 
-if (argv['profile']) {
+if (argv['profile-dir']) {
+    app.setPath('userData', argv['profile-dir']);
+} else if (argv['profile']) {
     app.setPath('userData', `${app.getPath('userData')}-${argv['profile']}`);
 }
 


### PR DESCRIPTION
A custom user data directory can now be specified using the "profile-dir" command line argument.

This PR solves https://github.com/vector-im/riot-web/issues/6175.