### PR TITLE
Validate default homeserver config before loading the app

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,9 @@ For a good example, see https://riot.im/develop/config.json.
    with added support for a `server_name` under the `m.homeserver` section to display
    a custom homeserver name. Alternatively, the config can contain a `default_server_name`
    instead which is where Riot will go to get that same object - see the `.well-known`
-   link above for more information.
+   link above for more information. Note that the `default_server_name` is used to get
+   a complete server configuration whereas the `server_name` in the `default_server_config`
+   is for display purposes only.
    * *Note*: The URLs can also be individually specified as `default_hs_url` and 
      `default_is_url`, however these are deprecated. They are maintained for backwards
      compatibility with older configurations. `default_is_url` is respected only

--- a/README.md
+++ b/README.md
@@ -109,25 +109,29 @@ You can configure the app by copying `config.sample.json` to
 
 For a good example, see https://riot.im/develop/config.json.
 
-1. `default_server_name` sets the default server name to use for authentication.
-   This will trigger Riot to ask
-   `https://<server_name>/.well-known/matrix/client` for the homeserver and
-   identity server URLs to use. This is the recommended approach for setting a
-   default server. However, it is also possible to use the following to directly
-   configure each of the URLs:
-   * `default_hs_url` sets the default homeserver URL.
-   * `default_is_url` sets the default identity server URL (this is the server used
-      for verifying third party identifiers like email addresses). If this is blank,
-      registering with an email address, adding an email address to your account,
-      or inviting users via email address will not work.  Matrix identity servers are
-      very simple web services which map third party identifiers (currently only email
-      addresses) to matrix IDs: see http://matrix.org/docs/spec/identity_service/unstable.html
-      for more details.  Currently the only public matrix identity servers are https://matrix.org
-      and https://vector.im.  In the future, identity servers will be decentralised.
-   * Riot will report an error if you accidentally configure both `default_server_name` _and_ `default_hs_url` since it's unclear which should take priority.
+1. `default_server_config` sets the default homeserver and identity server URL for
+   Riot to use. The object is the same as returned by [https://<server_name>/.well-known/matrix/client](https://matrix.org/docs/spec/client_server/latest.html#get-well-known-matrix-client),
+   with added support for a `server_name` under the `m.homeserver` section to display
+   a custom homeserver name. Alternatively, the config can contain a `default_server_name`
+   instead which is where Riot will go to get that same object - see the `.well-known`
+   link above for more information.
+   * *Note*: The URLs can also be individually specified as `default_hs_url` and 
+     `default_is_url`, however these are deprecated. They are maintained for backwards
+     compatibility with older configurations. `default_is_url` is respected only
+     if `default_hs_url` is used.
+   * The identity server is used for verifying third party identifiers like emails
+     and phone numbers. It is not used to store your password or account information.
+     If not provided, the identity server defaults to vector.im unless `disable_identity_server`
+     is set to true in the config. Currently the only two public identity servers
+     are https://matrix.org and https://vector.im, however in future identity servers
+     will be decentralised.
+   * Riot will fail to load if a mix of `default_server_config`, `default_server_name`, or
+     `default_hs_url` is specified. When multiple sources are specified, it is unclear
+     which should take priority and therefore the application cannot continue.
 1. `features`: Lookup of optional features that may be `enable`d, `disable`d, or exposed to the user
    in the `labs` section of settings.  The available optional experimental features vary from
-   release to release.
+   release to release. Some of the available features are described in the Labs Feature section
+   of this README.
 1. `brand`: String to pass to your homeserver when configuring email notifications, to let the
    homeserver know what email template to use when talking to you.
 1. `branding`: Configures various branding and logo details, such as:

--- a/config.sample.json
+++ b/config.sample.json
@@ -1,6 +1,14 @@
 {
-    "default_hs_url": "https://matrix.org",
-    "default_is_url": "https://vector.im",
+    "default_server_config": {
+        "m.homeserver": {
+            "base_url": "https://matrix.org",
+            "server_name": "matrix.org"
+        },
+        "m.identity_server": {
+            "base_url": "https://vector.im"
+        }
+    },
+    "disable_identity_server": false,
     "disable_custom_urls": false,
     "disable_guests": false,
     "disable_login_language_selector": false,

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -1,7 +1,6 @@
 {
     "Unexpected error preparing the app. See console for details.": "Unexpected error preparing the app. See console for details.",
     "Invalid configuration: can only specify one of default_server_config, default_server_name, or default_hs_url.": "Invalid configuration: can only specify one of default_server_config, default_server_name, or default_hs_url.",
-    "Unexpected error resolving homeserver configuration": "Unexpected error resolving homeserver configuration",
     "Riot Desktop on %(platformName)s": "Riot Desktop on %(platformName)s",
     "Unknown device": "Unknown device",
     "%(appName)s via %(browserName)s on %(osName)s": "%(appName)s via %(browserName)s on %(osName)s",

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -1,4 +1,7 @@
 {
+    "Unexpected error preparing the app. See console for details.": "Unexpected error preparing the app. See console for details.",
+    "Invalid configuration: can only specify one of default_server_config, default_server_name, or default_hs_url.": "Invalid configuration: can only specify one of default_server_config, default_server_name, or default_hs_url.",
+    "Unexpected error resolving homeserver configuration": "Unexpected error resolving homeserver configuration",
     "Riot Desktop on %(platformName)s": "Riot Desktop on %(platformName)s",
     "Unknown device": "Unknown device",
     "%(appName)s via %(browserName)s on %(osName)s": "%(appName)s via %(browserName)s on %(osName)s",
@@ -15,7 +18,5 @@
     "Need help?": "Need help?",
     "Chat with Riot Bot": "Chat with Riot Bot",
     "Explore rooms": "Explore rooms",
-    "Room Directory": "Room Directory",
-    "Search the room directory": "Search the room directory",
-    "Get started with some tips from Riot Bot!": "Get started with some tips from Riot Bot!"
+    "Room Directory": "Room Directory"
 }

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -1,7 +1,7 @@
 {
     "Unexpected error preparing the app. See console for details.": "Unexpected error preparing the app. See console for details.",
     "Invalid configuration: can only specify one of default_server_config, default_server_name, or default_hs_url.": "Invalid configuration: can only specify one of default_server_config, default_server_name, or default_hs_url.",
-    "Invalid configuration: no default server specified": "Invalid configuration: no default server specified",
+    "Invalid configuration: no default server specified.": "Invalid configuration: no default server specified.",
     "Riot Desktop on %(platformName)s": "Riot Desktop on %(platformName)s",
     "Unknown device": "Unknown device",
     "%(appName)s via %(browserName)s on %(osName)s": "%(appName)s via %(browserName)s on %(osName)s",

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -1,6 +1,7 @@
 {
     "Unexpected error preparing the app. See console for details.": "Unexpected error preparing the app. See console for details.",
     "Invalid configuration: can only specify one of default_server_config, default_server_name, or default_hs_url.": "Invalid configuration: can only specify one of default_server_config, default_server_name, or default_hs_url.",
+    "Invalid configuration: no default server specified": "Invalid configuration: no default server specified",
     "Riot Desktop on %(platformName)s": "Riot Desktop on %(platformName)s",
     "Unknown device": "Unknown device",
     "%(appName)s via %(browserName)s on %(osName)s": "%(appName)s via %(browserName)s on %(osName)s",

--- a/src/vector/index.js
+++ b/src/vector/index.js
@@ -494,30 +494,13 @@ async function verifyServerConfig() {
     }
 
     const validatedConfig = AutoDiscoveryUtils.buildValidatedConfigFromDiscovery(serverName, result);
+
+    // Just in case we ever have to debug this
     console.log("Using homeserver config:", validatedConfig);
-
-    // Build our own discovery result for distribution within the app
-    const configResult = {
-        "m.homeserver": {
-            "base_url": validatedConfig.hsUrl,
-            "server_name": validatedConfig.hsName,
-            "server_name_different": validatedConfig.hsNameIsDifferent,
-        },
-        "m.identity_server": {
-            "base_url": validatedConfig.isUrl,
-            "enabled": validatedConfig.identityEnabled,
-        },
-    };
-
-    // Copy over any other keys that may be of interest
-    for (const key of Object.keys(result)) {
-        if (key === "m.homeserver" || key === "m.identity_server") continue;
-        configResult[key] = JSON.parse(JSON.stringify(result[key])); // deep clone
-    }
 
     // Add the newly built config to the actual config for use by the app
     console.log("Updating SdkConfig with validated discovery information");
-    SdkConfig.add({"validated_discovery_config": configResult});
+    SdkConfig.add({"validated_discovery_config": validatedConfig});
 
     return SdkConfig.get();
 }

--- a/src/vector/index.js
+++ b/src/vector/index.js
@@ -448,20 +448,6 @@ async function loadLanguage() {
 async function verifyServerConfig() {
     console.log("Verifying homeserver configuration");
 
-    // Errors which can be returned by .well-known lookups. If autodiscovery fails for unexpected reasons,
-    // the last thing we want is "missing-translation|en:Your error here". The actual strings are also defined
-    // in the react-sdk, so we don't need them here.
-    const discoveryErrors = [
-        "Invalid homeserver discovery response",
-        "Failed to get autodiscovery configuration from server",
-        "Invalid base_url for m.homeserver",
-        "Homeserver URL does not appear to be a valid Matrix homeserver",
-        "Invalid identity server discovery response",
-        "Invalid base_url for m.identity_server",
-        "Identity server URL does not appear to be a valid identity server",
-        "General failure",
-    ];
-
     const config = SdkConfig.get();
     let wkConfig = config['default_server_config']; // overwritten later under some conditions
     const serverName = config['default_server_name'];
@@ -512,7 +498,7 @@ async function verifyServerConfig() {
 
     const hsResult = result['m.homeserver'];
     if (hsResult.state !== AutoDiscovery.SUCCESS) {
-        if (discoveryErrors.indexOf(hsResult.error) !== -1) {
+        if (AutoDiscovery.ALL_ERRORS.indexOf(hsResult.error) !== -1) {
             throw newTranslatableError(hsResult.error);
         }
         throw newTranslatableError(_td("Unexpected error resolving homeserver configuration"));

--- a/src/vector/index.js
+++ b/src/vector/index.js
@@ -448,6 +448,9 @@ async function loadLanguage() {
 async function verifyServerConfig() {
     console.log("Verifying homeserver configuration");
 
+    // TODO: Handle query string arguments for hs_url and is_url
+    // We probably don't want to handle them unless the user is logged out though?
+
     const config = SdkConfig.get();
     let wkConfig = config['default_server_config']; // overwritten later under some conditions
     const serverName = config['default_server_name'];

--- a/src/vector/index.js
+++ b/src/vector/index.js
@@ -500,7 +500,7 @@ async function verifyServerConfig() {
 
     // Add the newly built config to the actual config for use by the app
     console.log("Updating SdkConfig with validated discovery information");
-    SdkConfig.add({"validated_discovery_config": validatedConfig});
+    SdkConfig.add({"validated_server_config": validatedConfig});
 
     return SdkConfig.get();
 }

--- a/src/vector/index.js
+++ b/src/vector/index.js
@@ -449,8 +449,10 @@ async function loadLanguage() {
 async function verifyServerConfig() {
     console.log("Verifying homeserver configuration");
 
-    // TODO: Handle query string arguments for hs_url and is_url
+    // TODO: TravisR - Handle query string arguments for hs_url and is_url
     // We probably don't want to handle them unless the user is logged out though?
+
+    // TODO: TravisR - Handle case of no options specified whatsoever
 
     const config = SdkConfig.get();
     let wkConfig = config['default_server_config']; // overwritten later under some conditions

--- a/src/vector/index.js
+++ b/src/vector/index.js
@@ -452,8 +452,6 @@ async function verifyServerConfig() {
     // TODO: TravisR - Handle query string arguments for hs_url and is_url
     // We probably don't want to handle them unless the user is logged out though?
 
-    // TODO: TravisR - Handle case of no options specified whatsoever
-
     const config = SdkConfig.get();
     let wkConfig = config['default_server_config']; // overwritten later under some conditions
     const serverName = config['default_server_name'];
@@ -466,6 +464,9 @@ async function verifyServerConfig() {
             "Invalid configuration: can only specify one of default_server_config, default_server_name, " +
             "or default_hs_url.",
         ));
+    }
+    if (incompatibleOptions.length < 1) {
+        throw newTranslatableError(_td("Invalid configuration: no default server specified."));
     }
 
     if (hsUrl) {

--- a/test/app-tests/joining.js
+++ b/test/app-tests/joining.js
@@ -37,6 +37,8 @@ const ReactDOM = require('react-dom');
 const ReactTestUtils = require('react-addons-test-utils');
 const expect = require('expect');
 import Promise from 'bluebird';
+import {makeType} from "matrix-react-sdk/lib/utils/TypeUtils";
+import {ValidatedServerConfig} from "matrix-react-sdk/lib/utils/AutoDiscoveryUtils";
 
 const test_utils = require('../test-utils');
 const MockHttpBackend = require('matrix-mock-request');
@@ -97,17 +99,19 @@ describe('joining a room', function() {
             PlatformPeg.set(new WebPlatform());
 
             const config = {
-                validated_server_config: {
+                validated_server_config: makeType(ValidatedServerConfig, {
                     hsUrl: HS_URL,
                     hsName: "TEST_ENVIRONMENT",
                     hsNameIsDifferent: false, // yes, we lie
                     isUrl: IS_URL,
                     identityEnabled: true,
-                },
+                }),
             };
 
             const mc = (
-                <MatrixChat config={config}
+                <MatrixChat
+                    config={config}
+                    serverConfig={config.validated_server_config}
                     makeRegistrationUrl={()=>{throw new Error("unimplemented");}}
                     initialScreenAfterLogin={{
                         screen: 'directory',

--- a/test/app-tests/joining.js
+++ b/test/app-tests/joining.js
@@ -96,8 +96,18 @@ describe('joining a room', function() {
 
             PlatformPeg.set(new WebPlatform());
 
+            const config = {
+                validated_server_config: {
+                    hsUrl: HS_URL,
+                    hsName: "TEST_ENVIRONMENT",
+                    hsNameIsDifferent: false, // yes, we lie
+                    isUrl: IS_URL,
+                    identityEnabled: true,
+                },
+            };
+
             const mc = (
-                <MatrixChat config={{}}
+                <MatrixChat config={config}
                     makeRegistrationUrl={()=>{throw new Error("unimplemented");}}
                     initialScreenAfterLogin={{
                         screen: 'directory',

--- a/test/app-tests/loading.js
+++ b/test/app-tests/loading.js
@@ -39,6 +39,8 @@ import dis from 'matrix-react-sdk/lib/dispatcher';
 import * as test_utils from '../test-utils';
 import MockHttpBackend from 'matrix-mock-request';
 import {parseQs, parseQsFromFragment} from '../../src/vector/url_utils';
+import {makeType} from "matrix-react-sdk/lib/utils/TypeUtils";
+import {ValidatedServerConfig} from "matrix-react-sdk/lib/utils/AutoDiscoveryUtils";
 
 const DEFAULT_HS_URL='http://my_server';
 const DEFAULT_IS_URL='http://my_is';
@@ -146,13 +148,13 @@ describe('loading:', function() {
         const config = Object.assign({
             default_hs_url: DEFAULT_HS_URL,
             default_is_url: DEFAULT_IS_URL,
-            validated_server_config: {
+            validated_server_config: makeType(ValidatedServerConfig, {
                 hsUrl: DEFAULT_HS_URL,
                 hsName: "TEST_ENVIRONMENT",
                 hsNameIsDifferent: false, // yes, we lie
                 isUrl: DEFAULT_IS_URL,
                 identityEnabled: true,
-            },
+            }),
             embeddedPages: {
                 homeUrl: 'data:text/html;charset=utf-8;base64,PGh0bWw+PC9odG1sPg==',
             },
@@ -167,6 +169,7 @@ describe('loading:', function() {
                 <MatrixChat
                     onNewScreen={onNewScreen}
                     config={config}
+                    serverConfig={config.validated_server_config}
                     realQueryParams={params}
                     startingFragmentQueryParams={fragParts.params}
                     enableGuest={true}
@@ -623,10 +626,20 @@ describe('loading:', function() {
 
     // check that we have a Login component, send a 'user:pass' login,
     // and await the HTTP requests.
-    function completeLogin(matrixChat) {
+    async function completeLogin(matrixChat) {
         // we expect a single <Login> component
         const login = ReactTestUtils.findRenderedComponentWithType(
             matrixChat, sdk.getComponent('structures.auth.Login'));
+
+        // When we switch to the login component, it'll hit the login endpoint
+        // for proof of life and to get flows. We'll only give it one option.
+        httpBackend.when('GET', '/login')
+            .respond(200, {"flows": [{"type": "m.login.password"}]});
+        httpBackend.flush(); // We already would have tried the GET /login request
+
+        // Give the component some time to finish processing the login flows before
+        // continuing.
+        await Promise.delay(100);
 
         httpBackend.when('POST', '/login').check(function(req) {
             expect(req.data.type).toEqual('m.login.password');

--- a/test/app-tests/loading.js
+++ b/test/app-tests/loading.js
@@ -146,6 +146,13 @@ describe('loading:', function() {
         const config = Object.assign({
             default_hs_url: DEFAULT_HS_URL,
             default_is_url: DEFAULT_IS_URL,
+            validated_server_config: {
+                hsUrl: DEFAULT_HS_URL,
+                hsName: "TEST_ENVIRONMENT",
+                hsNameIsDifferent: false, // yes, we lie
+                isUrl: DEFAULT_IS_URL,
+                identityEnabled: true,
+            },
             embeddedPages: {
                 homeUrl: 'data:text/html;charset=utf-8;base64,PGh0bWw+PC9odG1sPg==',
             },


### PR DESCRIPTION
**Reviewer**: This is generally best reviewed as the final diff rather than the individual commits. Note that there's a TODO comment in the diff which has the intention of being followed up by a later PR - the PRs for this work item are getting a bit large, so this is being put up for review with a known deficiency. 

The TODO comment affects those who happen to use https://riot.im/develop/#/login?hs_url=https://matrix.org instead of the other options. It may also affect people's ability to claim 3pid validations.

See https://github.com/vector-im/riot-web/issues/9290
Fixes https://github.com/vector-im/riot-web/issues/8826

**Please review with https://github.com/matrix-org/matrix-react-sdk/pull/2941** (the implementation)

----

Implements the process described here: https://github.com/vector-im/riot-web/issues/9290#issuecomment-481966910

The expectation is that later layers (like the react-sdk) will make use of the `validated_discovery_config` option instead of interpreting the config themselves.

We intentionally block the UI from loading here to avoid races between discovery and the app loading.

~~Requires https://github.com/matrix-org/matrix-js-sdk/pull/897~~ Merged.

----

~~**Blocked on clarification regarding identity server behaviour.**~~ Going forward with this as-proposed with the intention of verifying that this is the correct behaviour.

We strive for not having defaults anymore, however the identity server is optional across the stack. Additionally, there is some concern that the federation is torn on whether or not .well-known should include an identity server:
```
Total servers: 966

Responses by discovery state
----------------------------
STATE               | COUNT | PERCENT
wk_not_found        | 463   | 47.93 %
has_identity_server | 101   | 10.46 %
no_identity_server  | 69    | 7.14 %
error               | 333   | 34.47 %
```
(sampled from #riot-web, #matrix, and #riot-web-announcements)