### PR TITLE
update installation instructions with new repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ released version of Riot:
 1. Enter the URL into your browser and log into Riot!
 
 Releases are signed using gpg and the OpenPGP standard, and can be checked against the public key located
-at https://packages.riot.im/debian/riot.im-archive-keyring.asc .
+at https://packages.riot.im/riot-release-key.asc.
 
 Note that Chrome does not allow microphone or webcam access for sites served
 over http (except localhost), so for working VoIP you will need to serve Riot
@@ -39,9 +39,9 @@ over https.
   - As a separate entry in sources.list.d:
 `echo "deb https://packages.riot.im/debian/ stretch main" | sudo tee /etc/apt/sources.list.d/riot.list`
 2. Download and add the gpg signing key used to authenticate the packages from the riot repository to your system's list of trusted keys:
-`curl -s https://packages.riot.im/debian/riot.im-archive-keyring.asc | sudo apt-key add -`
+`curl -s https://packages.riot.im/debian/riot-im-archive-keyring.asc | sudo apt-key add -`
 - Optional: if you had the old Riot.im signing key in your apt keyring, delete it, as it is no longer considered trusted:
-`sudo apt-key del 48E8F4A1`
+`sudo apt-key del 0x48E8F4A1`
 3. Update your package lists:
 `sudo apt update`
 4. Install Riot:

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ over https.
 `echo "deb https://packages.riot.im/debian/ stretch main" | sudo tee -a /etc/apt/sources.list`
   - As a separate entry in sources.list.d:
 `echo "deb https://packages.riot.im/debian/ stretch main" | sudo tee /etc/apt/sources.list.d/riot.list`
-2. Download and add the gpg signing key used to authentify the packages from the riot repository to your system's list of trusted keys:
+2. Download and add the gpg signing key used to authenticate the packages from the riot repository to your system's list of trusted keys:
 `curl -s https://packages.riot.im/debian/repo-key.asc | sudo apt-key add -`
 - Optional: if you had the old Riot.im signing key in your apt keyring, delete it, as it is no longer considered trusted:
 `sudo apt-key del 48E8F4A1`

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ released version of Riot:
 1. Enter the URL into your browser and log into Riot!
 
 Releases are signed using gpg and the OpenPGP standard, and can be checked against the public key located
-at https://packages.riot.im/keys/riot.asc .
+at https://packages.riot.im/debian/riot.im-archive-keyring.asc .
 
 Note that Chrome does not allow microphone or webcam access for sites served
 over http (except localhost), so for working VoIP you will need to serve Riot
@@ -39,7 +39,7 @@ over https.
   - As a separate entry in sources.list.d:
 `echo "deb https://packages.riot.im/debian/ stretch main" | sudo tee /etc/apt/sources.list.d/riot.list`
 2. Download and add the gpg signing key used to authenticate the packages from the riot repository to your system's list of trusted keys:
-`curl -s https://packages.riot.im/debian/repo-key.asc | sudo apt-key add -`
+`curl -s https://packages.riot.im/debian/riot.im-archive-keyring.asc | sudo apt-key add -`
 - Optional: if you had the old Riot.im signing key in your apt keyring, delete it, as it is no longer considered trusted:
 `sudo apt-key del 48E8F4A1`
 3. Update your package lists:

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ released version of Riot:
    as desired. See below for details.
 1. Enter the URL into your browser and log into Riot!
 
-Releases are signed by PGP, and can be checked against the public key
-at https://riot.im/packages/keys/riot.asc .
+Releases are signed using gpg and the OpenPGP standard, and can be checked against the public key located
+at https://packages.riot.im/keys/riot.asc .
 
 Note that Chrome does not allow microphone or webcam access for sites served
 over http (except localhost), so for working VoIP you will need to serve Riot
@@ -34,11 +34,18 @@ over https.
 ### Desktop Installation for Debian Stretch
 
 1. Add the repository to your sources.list using either of the following two options:
-  - Directly to sources.list: `echo "deb https://riot.im/packages/debian/ stretch main" | sudo tee -a /etc/apt/sources.list`
-  - As a separate entry in sources.list.d: `echo "deb https://riot.im/packages/debian/ stretch main" | sudo tee /etc/apt/sources.list.d/riot.list`
-2. Add the gpg signing key for the riot repository: `curl -s https://riot.im/packages/debian/repo-key.asc | sudo apt-key add -`
-3. Update your package lists: `sudo apt-get update`
-4. Install Riot: `sudo apt-get install riot-web`
+  - Directly to sources.list:
+`echo "deb https://packages.riot.im/debian/ stretch main" | sudo tee -a /etc/apt/sources.list`
+  - As a separate entry in sources.list.d:
+`echo "deb https://packages.riot.im/debian/ stretch main" | sudo tee /etc/apt/sources.list.d/riot.list`
+2. Download and add the gpg signing key used to authentify the packages from the riot repository to your system's list of trusted keys:
+`curl -s https://packages.riot.im/debian/repo-key.asc | sudo apt-key add -`
+- Optional: if you had the old Riot.im signing key in your apt keyring, delete it, as it is no longer considered trusted:
+`sudo apt-key del 48E8F4A1`
+3. Update your package lists:
+`sudo apt update`
+4. Install Riot:
+`sudo apt install riot-web`
 
 Important Security Note
 =======================


### PR DESCRIPTION
- change mentions of https://riot.im/packages to https://packages.riot.im
- add instructions to remove old, now-untrusted riot.im signing key
- update language and move from `apt-get` to the simpler `apt`

Signed-off-by: axel simon `<axelsimon at axelsimon.net>`