### PR TITLE
Don't fail if there's no local config to remove

### DIFF
--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -24,7 +24,7 @@ mkdir -p dist
 cp -r webapp riot-$version
 
 # Just in case you have a local config, remove it before packaging
-rm riot-$version/config.json
+rm riot-$version/config.json || true
 
 # if $version looks like semver with leading v, strip it before writing to file
 if [[ ${version} =~ ^v[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+(-.+)?$ ]]; then


### PR DESCRIPTION
The script has a set -e so don't fail if there's nothing to rm

This raises the question of whether we want to be copying config.json from the root to webapp/ at all (which we do in copy-res.js) - I don't think we want it in the general case and for the electron build we can put it straight into webapp/ instead.

Either way I think we want this though.