### PR TITLE
Delay creating the `Favico` instance

### DIFF
--- a/src/vector/platform/VectorBasePlatform.js
+++ b/src/vector/platform/VectorBasePlatform.js
@@ -39,20 +39,31 @@ export default class VectorBasePlatform extends BasePlatform {
     constructor() {
         super();
 
-        // The 'animations' are really low framerate and look terrible.
-        // Also it re-starts the animation every time you set the badge,
-        // and we set the state each time, even if the value hasn't changed,
-        // so we'd need to fix that if enabling the animation.
-        this.favicon = new Favico({animation: 'none'});
         this.showUpdateCheck = false;
-        this._updateFavicon();
-
         this.startUpdateCheck = this.startUpdateCheck.bind(this);
         this.stopUpdateCheck = this.stopUpdateCheck.bind(this);
     }
 
     getHumanReadableName(): string {
         return 'Vector Base Platform'; // no translation required: only used for analytics
+    }
+
+    /**
+     * Delay creating the `Favico` instance until first use (on the first notification) as
+     * it uses canvas, which can trigger a permission prompt in Firefox's resist
+     * fingerprinting mode.
+     * See https://github.com/vector-im/riot-web/issues/9605.
+     */
+    get favicon() {
+        if (this._favicon) {
+            return this._favicon;
+        }
+        // The 'animations' are really low framerate and look terrible.
+        // Also it re-starts the animation every time you set the badge,
+        // and we set the state each time, even if the value hasn't changed,
+        // so we'd need to fix that if enabling the animation.
+        this._favicon = new Favico({ animation: 'none' });
+        return this._favicon;
     }
 
     _updateFavicon() {


### PR DESCRIPTION
This avoids a canvas permission prompt from appearing on page load for users in
Firefox's resist fingerprinting mode. The prompt will still happen once you log
in and receive a notification, but at least this prevents it from happening
during the initial app experience.

Fixes https://github.com/vector-im/riot-web/issues/9605