### PR TITLE
Put back default Electron zoom in option (in addition to the one added in #8381)

### DIFF
--- a/electron_app/src/vectormenu.js
+++ b/electron_app/src/vectormenu.js
@@ -37,6 +37,7 @@ const template = [
         submenu: [
             { type: 'separator' },
             { role: 'resetzoom' },
+            { role: 'zoomin' },
             { role: 'zoomin', accelerator: 'CommandOrControl+=' },
             { role: 'zoomout' },
             { type: 'separator' },


### PR DESCRIPTION
Fixes? #9533