### PR TITLE
Clarify comment on is_url and hs_url handling

### DIFF
--- a/src/vector/index.js
+++ b/src/vector/index.js
@@ -449,8 +449,9 @@ async function loadLanguage() {
 async function verifyServerConfig() {
     console.log("Verifying homeserver configuration");
 
-    // TODO: TravisR - Handle query string arguments for hs_url and is_url
-    // We probably don't want to handle them unless the user is logged out though?
+    // Note: the query string may include is_url and hs_url - we only respect these in the
+    // context of email validation. Because we don't respect them otherwise, we do not need
+    // to parse or consider them here.
 
     const config = SdkConfig.get();
     let wkConfig = config['default_server_config']; // overwritten later under some conditions


### PR DESCRIPTION
**Reviewer**: Note that this is pointed at the .well-known feature branch, not develop. This is intentional as the feature branch is still unsafe to merge to develop.

We don't actually need to do anything because the app transparently handles this.

See https://github.com/vector-im/riot-web/issues/9290