### PR TITLE
Flag the validated config as the default config

### DIFF
--- a/src/vector/index.js
+++ b/src/vector/index.js
@@ -497,6 +497,7 @@ async function verifyServerConfig() {
     }
 
     const validatedConfig = AutoDiscoveryUtils.buildValidatedConfigFromDiscovery(serverName, result);
+    validatedConfig.isDefault = true;
 
     // Just in case we ever have to debug this
     console.log("Using homeserver config:", validatedConfig);


### PR DESCRIPTION
**Reviewer**: Note that this is pointed at the .well-known feature branch, not develop. This is intentional as the feature branch is still unsafe to merge to develop.

See https://github.com/vector-im/riot-web/issues/9290
Paired with https://github.com/matrix-org/matrix-react-sdk/pull/2971