### PR TITLE
Make Dockerfile work for develop and other branches

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ WORKDIR /src
 
 COPY . /src
 RUN dos2unix /src/scripts/docker-link-repos.sh && sh /src/scripts/docker-link-repos.sh
-RUN yarn install
+RUN yarn --network-timeout=100000 install
 RUN yarn build
 
 # Copy the config now so that we don't create another layer in the app image

--- a/scripts/docker-link-repos.sh
+++ b/scripts/docker-link-repos.sh
@@ -13,7 +13,7 @@ git clone $JS_SDK_REPO js-sdk
 cd js-sdk
 git checkout $JS_SDK_BRANCH
 yarn link
-yarn install
+yarn --network-timeout=100000 install
 cd ../
 
 echo "Linking react-sdk"
@@ -22,7 +22,7 @@ cd react-sdk
 git checkout $REACT_SDK_BRANCH
 yarn link
 yarn link matrix-js-sdk
-yarn install
+yarn --network-timeout=100000 install
 cd ../
 
 echo "Setting up riot-web with react-sdk and js-sdk packages"


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/9701 (by not timing out, allowing us to use Docker Hub again)
Fixes https://github.com/vector-im/riot-web/issues/9606 (the rules are already set up, we just need to have something to build 😄)

We force yarn to use a longer network timeout because Docker Hub's limited machines are not capable of downloading the resources fast enough. The tests I've performed on this branch have not failed due to network timeouts, so the value is presumed high enough. 

**Note**: Docker Hub is slow, our builds easily take 20-40 minutes to complete.
