### PR TITLE
Base Docker image on nginx:alpine, not the larger nginx:latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN cp /src/config.sample.json /src/webapp/config.json
 
 
 # App
-FROM nginx:latest
+FROM nginx:alpine
 
 COPY --from=builder /src/webapp /app
 


### PR DESCRIPTION
`nginx:latest` is based on Debian Stretch and is listed as being 45MB,
while `nginx:alpine` is based on Alpine 3.9 and is just 7MB.

Basing the riot-web Docker image on `nginx:alpine` should
make it 38MB smaller compared to the current situation.

The nginx version seems to be "latest mainline" on both (currently 1.15.12),
judging by each Dockerfile:
- https://github.com/nginxinc/docker-nginx/blob/e5123eea0d29c8d13df17d782f15679458ff899e/mainline/stretch/Dockerfile
- https://github.com/nginxinc/docker-nginx/blob/e5123eea0d29c8d13df17d782f15679458ff899e/mainline/alpine/Dockerfile

Signed-off-by: Slavi Pantaleev <slavi@devture.com>