### PR TITLE
Move config-getting to VectorBasePlatform

### DIFF
--- a/electron_app/src/electron-main.js
+++ b/electron_app/src/electron-main.js
@@ -1,8 +1,8 @@
 /*
 Copyright 2016 Aviral Dasgupta
 Copyright 2016 OpenMarket Ltd
-Copyright 2017 Michael Telatynski <7t3chguy@gmail.com>
 Copyright 2018 New Vector Ltd
+Copyright 2017, 2019 Michael Telatynski <7t3chguy@gmail.com>
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -172,6 +172,9 @@ ipcMain.on('ipcCall', async function(ev, payload) {
             migratingOrigin = true;
             await migrateFromOldOrigin();
             migratingOrigin = false;
+            break;
+        case 'getConfig':
+            ret = vectorConfig;
             break;
         default:
             mainWindow.webContents.send('ipcReply', {

--- a/src/vector/getconfig.js
+++ b/src/vector/getconfig.js
@@ -34,7 +34,7 @@ export async function getVectorConfig(relativeLocation) {
     }
 }
 
-export function getConfig(configJsonFilename) {
+function getConfig(configJsonFilename) {
     return new Promise(function(resolve, reject) {
         request(
             { method: "GET", url: configJsonFilename },

--- a/src/vector/getconfig.js
+++ b/src/vector/getconfig.js
@@ -17,6 +17,8 @@ limitations under the License.
 import Promise from 'bluebird';
 import request from 'browser-request';
 
+// Load the config file. First try to load up a domain-specific config of the
+// form "config.$domain.json" and if that fails, fall back to config.json.
 export async function getVectorConfig(relativeLocation) {
     if (relativeLocation === undefined) relativeLocation = '';
     if (relativeLocation !== '' && !relativeLocation.endsWith('/')) relativeLocation += '/';
@@ -32,7 +34,7 @@ export async function getVectorConfig(relativeLocation) {
     }
 }
 
-function getConfig(configJsonFilename) {
+export function getConfig(configJsonFilename) {
     return new Promise(function(resolve, reject) {
         request(
             { method: "GET", url: configJsonFilename },

--- a/src/vector/index.js
+++ b/src/vector/index.js
@@ -117,7 +117,7 @@ function routeUrl(location) {
 }
 
 function onHashChange(ev) {
-    if (decodeURIComponent(window.location.hash) == lastLocationHashSet) {
+    if (decodeURIComponent(window.location.hash) === lastLocationHashSet) {
         // we just set this: no need to route it!
         return;
     }
@@ -157,7 +157,7 @@ function makeRegistrationUrl(params) {
 
     const keys = Object.keys(params);
     for (let i = 0; i < keys.length; ++i) {
-        if (i == 0) {
+        if (i === 0) {
             url += '?';
         } else {
             url += '&';
@@ -375,7 +375,7 @@ function loadOlm() {
     }).then(() => {
         console.log("Using WebAssembly Olm");
     }).catch((e) => {
-        console.log("Failed to load Olm: trying legacy version");
+        console.log("Failed to load Olm: trying legacy version", e);
         return new Promise((resolve, reject) => {
             const s = document.createElement('script');
             s.src = 'olm_legacy.js'; // XXX: This should be cache-busted too

--- a/src/vector/index.js
+++ b/src/vector/index.js
@@ -44,7 +44,6 @@ import PlatformPeg from 'matrix-react-sdk/lib/PlatformPeg';
 sdk.loadSkin(require('../component-index'));
 import VectorConferenceHandler from 'matrix-react-sdk/lib/VectorConferenceHandler';
 import Promise from 'bluebird';
-import request from 'browser-request';
 import * as languageHandler from 'matrix-react-sdk/lib/languageHandler';
 import {_t, _td, newTranslatableError} from 'matrix-react-sdk/lib/languageHandler';
 import AutoDiscoveryUtils from 'matrix-react-sdk/lib/utils/AutoDiscoveryUtils';

--- a/src/vector/platform/ElectronPlatform.js
+++ b/src/vector/platform/ElectronPlatform.js
@@ -4,6 +4,7 @@
 Copyright 2016 Aviral Dasgupta
 Copyright 2016 OpenMarket Ltd
 Copyright 2018 New Vector Ltd
+Copyright 2019 Michael Telatynski <7t3chguy@gmail.com>
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -99,6 +100,10 @@ export default class ElectronPlatform extends VectorBasePlatform {
 
         this.startUpdateCheck = this.startUpdateCheck.bind(this);
         this.stopUpdateCheck = this.stopUpdateCheck.bind(this);
+    }
+
+    async getConfig(): Promise<{}> {
+        return this._ipcCall('getConfig');
     }
 
     async onUpdateDownloaded(ev, updateInfo) {

--- a/src/vector/platform/VectorBasePlatform.js
+++ b/src/vector/platform/VectorBasePlatform.js
@@ -4,6 +4,7 @@
 Copyright 2016 Aviral Dasgupta
 Copyright 2016 OpenMarket Ltd
 Copyright 2018 New Vector Ltd
+Copyright 2019 Michael Telatynski <7t3chguy@gmail.com>
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -21,6 +22,7 @@ limitations under the License.
 import BasePlatform from 'matrix-react-sdk/lib/BasePlatform';
 import { _t } from 'matrix-react-sdk/lib/languageHandler';
 import dis from 'matrix-react-sdk/lib/dispatcher';
+import {getVectorConfig} from "../getconfig";
 
 import Favico from 'favico.js';
 
@@ -42,6 +44,10 @@ export default class VectorBasePlatform extends BasePlatform {
         this.showUpdateCheck = false;
         this.startUpdateCheck = this.startUpdateCheck.bind(this);
         this.stopUpdateCheck = this.stopUpdateCheck.bind(this);
+    }
+
+    async getConfig(): Promise<{}> {
+        return getVectorConfig();
     }
 
     getHumanReadableName(): string {


### PR DESCRIPTION
+ in Electron get config via IPC from main process which has access to the "local" config.json override file and can make people happy :D
+ Remove bunch of duplicated code,
+ and move comments around to put them in the right place

![image](https://user-images.githubusercontent.com/2403652/60211298-a424df00-9856-11e9-8f43-ffe6971420ae.png)

Fixes https://github.com/vector-im/riot-web/issues/9476

Signed-off-by: Michael Telatynski <7t3chguy@gmail.com>