### PR TITLE
Add e2e/warning.svg to preload

### DIFF
--- a/src/vector/index.html
+++ b/src/vector/index.html
@@ -41,6 +41,7 @@
     </script>
     <script src="<%= htmlWebpackPlugin.files.chunks['bundle'].entry %>"></script>
     <img src="<%= require('matrix-react-sdk/res/img/warning.svg') %>" width="24" height="23" style="visibility: hidden; position: absolute; top: 0px; left: 0px;"/>
+    <img src="<%= require('matrix-react-sdk/res/img/e2e/warning.svg') %>" width="24" height="23" style="visibility: hidden; position: absolute; top: 0px; left: 0px;"/>
     <audio id="messageAudio">
         <source src="media/message.ogg" type="audio/ogg" />
         <source src="media/message.mp3" type="audio/mpeg" />


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2403652/60296633-72774b00-991e-11e9-9fc0-23beac045112.png)

Fixes https://github.com/vector-im/riot-web/issues/10162

Signed-off-by: Michael Telatynski <7t3chguy@gmail.com>