### PR TITLE
Convert install-app-deps to subcommand

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "build": "yarn build:js-sdk && yarn build:react-sdk && yarn reskindex && yarn build:res && yarn build:bundle",
     "build:dev": "yarn build:js-sdk && yarn build:react-sdk && yarn reskindex && yarn build:res && yarn build:bundle:dev",
     "dist": "scripts/package.sh",
-    "install:electron": "install-app-deps",
+    "install:electron": "electron-builder install-app-deps",
     "electron": "yarn install:electron && electron .",
     "start:res": "node scripts/copy-res.js -w",
     "start:js": "webpack-dev-server --host=0.0.0.0 --output-filename=bundles/_dev_/[name].js --output-chunk-filename=bundles/_dev_/[name].js -w --progress --mode development",


### PR DESCRIPTION
Every time I run `yarn install:electron`, it complains with:

```
yarn run v1.13.0
$ install-app-deps
  • please use as subcommand: electron-builder install-app-deps
```

So, let's convert it to a subcommand.