### PR TITLE
Upgrade to Electron 5

### DIFF
--- a/electron_app/src/electron-main.js
+++ b/electron_app/src/electron-main.js
@@ -1,7 +1,7 @@
 /*
 Copyright 2016 Aviral Dasgupta
 Copyright 2016 OpenMarket Ltd
-Copyright 2018 New Vector Ltd
+Copyright 2018, 2019 New Vector Ltd
 Copyright 2017, 2019 Michael Telatynski <7t3chguy@gmail.com>
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -211,7 +211,14 @@ const launcher = new AutoLaunch({
 // work.
 // Also mark it as secure (ie. accessing resources from this
 // protocol and HTTPS won't trigger mixed content warnings).
-protocol.registerStandardSchemes(['vector'], {secure: true});
+protocol.registerSchemesAsPrivileged([{
+    scheme: 'vector',
+    privileges: {
+        standard: true,
+        secure: true,
+        supportFetchAPI: true,
+    },
+}]);
 
 app.on('ready', () => {
     if (argv['devtools']) {

--- a/electron_app/src/preload.js
+++ b/electron_app/src/preload.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 New Vector Ltd
+Copyright 2018, 2019 New Vector Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,16 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-const { ipcRenderer, webFrame } = require('electron');
+const { ipcRenderer } = require('electron');
 
 // expose ipcRenderer to the renderer process
 window.ipcRenderer = ipcRenderer;
-
-// Allow the fetch API to load resources from this
-// protocol: this is necessary to load olm.wasm.
-// (Also mark it a secure although we've already
-// done this in the main process).
-webFrame.registerURLSchemeAsPrivileged('vector', {
-    secure: true,
-    supportFetchAPI: true,
-});

--- a/package.json
+++ b/package.json
@@ -154,7 +154,7 @@
   },
   "build": {
     "appId": "im.riot.app",
-    "electronVersion": "4.2.6",
+    "electronVersion": "5.0.7",
     "files": [
       "node_modules/**",
       "src/**"


### PR DESCRIPTION
The APIs related to custom protocols went through some changes for Electron 5.x,
so adjusts Riot's usages to match.

I have scanned the Electron 5.x release notes, and I can't see anything else
that requires immediate changes. Things appear to be working well after the
upgrade.

Fixes https://github.com/vector-im/riot-web/issues/10296
Fixes https://github.com/vector-im/riot-web/issues/9562