### PR TITLE
Set SUID bit on chrome-sandbox for Debian

### DIFF
--- a/electron_app/build/linux/after-install.tpl
+++ b/electron_app/build/linux/after-install.tpl
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Link to the binary
+ln -sf '/opt/${productFilename}/${executable}' '/usr/bin/${executable}'
+
+# SUID chrome-sandbox for Electron 5+
+# Remove this custom after-install.tpl once this change has been upstreamed
+# https://github.com/electron-userland/electron-builder/pull/4163
+chmod 4755 '/opt/${productFilename}/chrome-sandbox' || true
+
+update-mime-database /usr/share/mime || true
+update-desktop-database /usr/share/applications || true

--- a/electron_app/build/linux/after-install.tpl
+++ b/electron_app/build/linux/after-install.tpl
@@ -4,7 +4,9 @@
 ln -sf '/opt/${productFilename}/${executable}' '/usr/bin/${executable}'
 
 # SUID chrome-sandbox for Electron 5+
-# Remove this custom after-install.tpl once this change has been upstreamed
+# Remove this entire file (after-install.tpl) and remove the reference in
+# package.json once this change has been upstreamed so we go back to the copy
+# from upstream.
 # https://github.com/electron-userland/electron-builder/pull/4163
 chmod 4755 '/opt/${productFilename}/chrome-sandbox' || true
 

--- a/package.json
+++ b/package.json
@@ -175,6 +175,9 @@
         "StartupWMClass": "riot"
       }
     },
+    "deb": {
+      "afterInstall": "electron_app/build/linux/after-install.tpl"
+    },
     "mac": {
       "category": "public.app-category.social-networking"
     },


### PR DESCRIPTION
This tweaks Linux packages for Riot to SUID `chrome-sandbox` after install. This
is required as of Electron 5 for certain distros, such as Debian.

This change has also been provided to `electron-builder` upstream, so ideally
they'll include it in the future and this becomes redundant.

Fixes https://github.com/vector-im/riot-web/issues/10509