### PR TITLE
Change integrations_widgets_urls default configuration

### DIFF
--- a/config.sample.json
+++ b/config.sample.json
@@ -15,6 +15,13 @@
     "brand": "Riot",
     "integrations_ui_url": "https://scalar.vector.im/",
     "integrations_rest_url": "https://scalar.vector.im/api",
+    "integrations_widgets_urls": [
+        "https://scalar.vector.im/_matrix/integrations/v1",
+        "https://scalar.vector.im/api",
+        "https://scalar-staging.vector.im/_matrix/integrations/v1",
+        "https://scalar-staging.vector.im/api",
+        "https://scalar-staging.riot.im/scalar/api"
+    ],
     "integrations_jitsi_widget_url": "https://scalar.vector.im/api/widgets/jitsi.html",
     "bug_report_endpoint_url": "https://riot.im/bugreports/submit",
     "defaultCountryCode": "GB",

--- a/electron_app/riot.im/config.json
+++ b/electron_app/riot.im/config.json
@@ -6,9 +6,11 @@
     "integrations_ui_url": "https://scalar.vector.im/",
     "integrations_rest_url": "https://scalar.vector.im/api",
     "integrations_widgets_urls": [
+        "https://scalar.vector.im/_matrix/integrations/v1",
+        "https://scalar.vector.im/api",
+        "https://scalar-staging.vector.im/_matrix/integrations/v1",
         "https://scalar-staging.vector.im/api",
-        "https://scalar-staging.riot.im/scalar/api",
-        "https://scalar.vector.im/api"
+        "https://scalar-staging.riot.im/scalar/api"
     ],
     "hosting_signup_link": "https://modular.im/?utm_source=riot-web&utm_medium=web",
     "bug_report_endpoint_url": "https://riot.im/bugreports/submit",

--- a/riot.im/app/config.json
+++ b/riot.im/app/config.json
@@ -5,8 +5,10 @@
     "integrations_ui_url": "https://scalar.vector.im/",
     "integrations_rest_url": "https://scalar.vector.im/api",
     "integrations_widgets_urls": [
-        "https://scalar-staging.vector.im/api",
+        "https://scalar.vector.im/_matrix/integrations/v1",
         "https://scalar.vector.im/api",
+        "https://scalar-staging.vector.im/_matrix/integrations/v1",
+        "https://scalar-staging.vector.im/api",
         "https://scalar-staging.riot.im/scalar/api"
     ],
     "hosting_signup_link": "https://modular.im/?utm_source=riot-web&utm_medium=web",

--- a/riot.im/develop/config.json
+++ b/riot.im/develop/config.json
@@ -5,9 +5,11 @@
     "integrations_ui_url": "https://scalar-staging.vector.im/",
     "integrations_rest_url": "https://scalar-staging.vector.im/api",
     "integrations_widgets_urls": [
-        "https://scalar-staging.riot.im/scalar/api",
+        "https://scalar.vector.im/_matrix/integrations/v1",
+        "https://scalar.vector.im/api",
+        "https://scalar-staging.vector.im/_matrix/integrations/v1",
         "https://scalar-staging.vector.im/api",
-        "https://scalar.vector.im/api"
+        "https://scalar-staging.riot.im/scalar/api"
     ],
     "hosting_signup_link": "https://modular.im/?utm_source=riot-web&utm_medium=web",
     "bug_report_endpoint_url": "https://riot.im/bugreports/submit",


### PR DESCRIPTION
Add and prioritize the new "_matrix/integrations/v1" widget urls

As per MSC1961, add to the whitelisted integrations_widget_urls
the new paths. This allows us to switch Scalar over to use the
new path as default.

Note, the legacy "scalar-staging.riot.im" is these days just a redirect
to scalar-staging.vector.im, so there is no addition for that. It still
needs Riot side whitelisting though for existing widgets.

Refs: https://github.com/matrix-org/matrix-doc/pull/1961

Provide our common integrations_widget_urls defaults for sample config

Closes: #10454