### PR TITLE
Fix origin migrator for SSO logins

### DIFF
--- a/electron_app/src/originMigrator.js
+++ b/electron_app/src/originMigrator.js
@@ -33,7 +33,11 @@ async function migrateFromOldOrigin() {
                 webgl: false,
             },
         });
-        ipcMain.once('origin_migration_complete', (e, success, sentSummary, storedSummary) => {
+        const onOriginMigrationComplete = (e, success, sentSummary, storedSummary) => {
+            // we use once but we'll only get once of these events,
+            // so remove the listener for the other one
+            ipcMain.removeListener('origin_migration_nodata', onOriginMigrationNoData);
+
             if (success) {
                 console.log("Origin migration completed successfully!");
             } else {
@@ -43,12 +47,18 @@ async function migrateFromOldOrigin() {
             console.error("Data stored", storedSummary);
             migrateWindow.close();
             resolve();
-        });
-        ipcMain.once('origin_migration_nodata', (e) => {
+        };
+        const onOriginMigrationNoData = (e, success, sentSummary, storedSummary) => {
+            ipcMain.removeListener('origin_migration_complete', onOriginMigrationComplete);
+
             console.log("No session to migrate from old origin");
             migrateWindow.close();
             resolve();
-        });
+        };
+
+        ipcMain.once('origin_migration_complete', onOriginMigrationComplete);
+        ipcMain.once('origin_migration_nodata', onOriginMigrationNoData);
+
         // Normalise the path because in the distribution, __dirname will be inside the
         // electron asar.
         const sourcePagePath = path.normalize(__dirname + '/../../origin_migrator/source.html');

--- a/electron_app/src/originMigrator.js
+++ b/electron_app/src/originMigrator.js
@@ -33,7 +33,7 @@ async function migrateFromOldOrigin() {
                 webgl: false,
             },
         });
-        ipcMain.on('origin_migration_complete', (e, success, sentSummary, storedSummary) => {
+        ipcMain.once('origin_migration_complete', (e, success, sentSummary, storedSummary) => {
             if (success) {
                 console.log("Origin migration completed successfully!");
             } else {
@@ -44,7 +44,7 @@ async function migrateFromOldOrigin() {
             migrateWindow.close();
             resolve();
         });
-        ipcMain.on('origin_migration_nodata', (e) => {
+        ipcMain.once('origin_migration_nodata', (e) => {
             console.log("No session to migrate from old origin");
             migrateWindow.close();
             resolve();

--- a/electron_app/src/originMigrator.js
+++ b/electron_app/src/originMigrator.js
@@ -34,7 +34,7 @@ async function migrateFromOldOrigin() {
             },
         });
         const onOriginMigrationComplete = (e, success, sentSummary, storedSummary) => {
-            // we use once but we'll only get once of these events,
+            // we use once but we'll only get one of these events,
             // so remove the listener for the other one
             ipcMain.removeListener('origin_migration_nodata', onOriginMigrationNoData);
 


### PR DESCRIPTION
For some reason this was trying to close the same window twice
when the app was reloaded after an SSO login. Possibly also a
problem on electron < 6 - presumably a race condition.

Merging to release branch