### PR TITLE
Request persistent storage on Electron

### DIFF
--- a/src/vector/platform/ElectronPlatform.js
+++ b/src/vector/platform/ElectronPlatform.js
@@ -100,6 +100,16 @@ export default class ElectronPlatform extends VectorBasePlatform {
 
         this.startUpdateCheck = this.startUpdateCheck.bind(this);
         this.stopUpdateCheck = this.stopUpdateCheck.bind(this);
+
+        this._tryPersistStorage();
+    }
+
+    async _tryPersistStorage() {
+        if (navigator.storage && navigator.storage.persist) {
+            const granted = await navigator.storage.persist();
+            const persisted = await navigator.storage.persisted();
+            console.log("Storage persist request granted: " + granted + " persisted: " + persisted);
+        }
     }
 
     async getConfig(): Promise<{}> {


### PR DESCRIPTION
It's still not 100% clear whether storage is always persistent on
Electron, but we seem to be getting reports of it being deleted in
the wild on Electron, so let's try calling the API to request
persistent storage. It won't pop up a dialog on Electron. In the
worst case it will give us some logging so we know what the API calls
return.

We could do this on non-desktop too but it's a bit of a mess because
Firefox prompts the user but Chrome makes a decision itself based on
how much the user visits the site.