### PR TITLE
Add config.json copy instruction to 'Development' as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,9 @@ bundle.css.map   116 kB       0  [emitted]  main
    and rebuilds source files when they change. This development server also
    disables caching, so do NOT use it in production.
 
+Configure the app by copying `config.sample.json` to `config.json` and
+modifying it. See the [configuration docs](docs/config.md) for details.
+
 Open http://127.0.0.1:8080/ in your browser to see your newly built Riot.
 
 ___


### PR DESCRIPTION
Copying the config sample is mentioned in the 'Getting Started' and the 'Building From Source' sections. However, when setting it up from the 'Building From Source' section, and then skipping to 'Setting up a dev environment' in step 6, the config won't have been copied yet. Therefore adding this step to the 'Setting up a dev environment' part as well.