### PR TITLE
Enable Webpack production mode for start:js:prod

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "electron": "yarn install:electron && electron .",
     "start:res": "node scripts/copy-res.js -w",
     "start:js": "webpack-dev-server --host=0.0.0.0 --output-filename=bundles/_dev_/[name].js --output-chunk-filename=bundles/_dev_/[name].js -w --progress --mode development",
-    "start:js:prod": "cross-env NODE_ENV=production webpack-dev-server -w --progress",
+    "start:js:prod": "cross-env NODE_ENV=production webpack-dev-server -w --progress --mode production",
     "start:js-sdk": "node scripts/yarn-sub.js matrix-js-sdk start:watch",
     "start:js-sdk:prod": "cross-env NODE_ENV=production node scripts/yarn-sub.js matrix-js-sdk start:watch",
     "start:react-sdk": "node scripts/yarn-sub.js matrix-react-sdk start:all",


### PR DESCRIPTION
The (rarely used) `start:js:prod` script for running production mode locally
failed to set Webpack into production mode, so things like minification would be
skipped.