### PR TITLE
Update default HS config to match well-known

### DIFF
--- a/riot.im/app/config.json
+++ b/riot.im/app/config.json
@@ -1,6 +1,13 @@
 {
-    "default_hs_url": "https://matrix.org",
-    "default_is_url": "https://vector.im",
+    "default_server_config": {
+        "m.homeserver": {
+            "server_name": "matrix.org",
+            "base_url": "https://matrix-client.matrix.org"
+        },
+        "m.identity_server": {
+            "base_url": "https://vector.im"
+        }
+    },
     "brand": "Riot",
     "integrations_ui_url": "https://scalar.vector.im/",
     "integrations_rest_url": "https://scalar.vector.im/api",


### PR DESCRIPTION
We want to move matrix.org client traffic to `https://matrix-client.matrix.org