### PR TITLE
Add darkModeSupport to allow dark themed title bar.

### DIFF
--- a/package.json
+++ b/package.json
@@ -177,7 +177,8 @@
       "afterInstall": "electron_app/build/linux/after-install.tpl"
     },
     "mac": {
-      "category": "public.app-category.social-networking"
+      "category": "public.app-category.social-networking",
+      "darkModeSupport": true
     },
     "win": {
       "target": {


### PR DESCRIPTION
Adding `"darkModeSupport": true` to the configuration adds an item to the Info.plist in the Mac app which allows the titlebar of Riot to change with the System theme (light, dark).

In `electron-builder`:
```ts
    if (this.platformSpecificBuildOptions.darkModeSupport) {
      appPlist.NSRequiresAquaSystemAppearance = false
    }
```
Source: https://github.com/electron-userland/electron-builder/blob/faba9e365a0a4d2402d91ca9bd5a5288cb78f0f7/packages/app-builder-lib/src/macPackager.ts#L313-315

Electron info: https://electronjs.org/docs/tutorial/mojave-dark-mode-guide

Before:
![riot-before](https://user-images.githubusercontent.com/1703598/66767692-4671dc80-eeb1-11e9-83fe-e89c866b7794.png)

After:
![riot-after](https://user-images.githubusercontent.com/1703598/66767698-47a30980-eeb1-11e9-9cfa-3375c723beb8.png)
