### PR TITLE
Remove unneeded help about identity servers

### DIFF
--- a/src/components/views/auth/VectorCustomServerDialog.js
+++ b/src/components/views/auth/VectorCustomServerDialog.js
@@ -1,6 +1,6 @@
 /*
 Copyright 2015, 2016 OpenMarket Ltd
-Copyright 2017 New Vector Ltd
+Copyright 2017, 2019 New Vector Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -34,11 +34,6 @@ module.exports = ({onFinished}) => {
                     "Matrix servers by specifying a different homeserver URL. This " +
                     "allows you to use Riot with an existing Matrix account on a " +
                     "different homeserver.",
-                )}</p>
-                <p>{_t(
-                    "You can also set a custom identity server, but you won't be " +
-                    "able to invite users by email address, or be invited by email " +
-                    "address yourself.",
                 )}</p>
             </div>
             <div className="mx_Dialog_buttons">

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -13,7 +13,6 @@
     "powered by Matrix": "powered by Matrix",
     "Custom Server Options": "Custom Server Options",
     "You can use the custom server options to sign into other Matrix servers by specifying a different homeserver URL. This allows you to use Riot with an existing Matrix account on a different homeserver.": "You can use the custom server options to sign into other Matrix servers by specifying a different homeserver URL. This allows you to use Riot with an existing Matrix account on a different homeserver.",
-    "You can also set a custom identity server, but you won't be able to invite users by email address, or be invited by email address yourself.": "You can also set a custom identity server, but you won't be able to invite users by email address, or be invited by email address yourself.",
     "Dismiss": "Dismiss",
     "Welcome to Riot.im": "Welcome to Riot.im",
     "Decentralised, encrypted chat &amp; collaboration powered by [matrix]": "Decentralised, encrypted chat &amp; collaboration powered by [matrix]",


### PR DESCRIPTION
The custom server path no longer shows an identity server field (for modern
homeservers), so it's confusing to have the help dialog reference it.

Fixes https://github.com/vector-im/riot-web/issues/11236