### PR TITLE
Fix bug preventing display from sleeping after a call

### DIFF
--- a/electron_app/src/electron-main.js
+++ b/electron_app/src/electron-main.js
@@ -118,16 +118,17 @@ ipcMain.on('loudNotification', function() {
     }
 });
 
-let powerSaveBlockerId;
+let powerSaveBlockerId = null;
 ipcMain.on('app_onAction', function(ev, payload) {
     switch (payload.action) {
         case 'call_state':
-            if (powerSaveBlockerId && powerSaveBlocker.isStarted(powerSaveBlockerId)) {
+            if (powerSaveBlockerId !== null && powerSaveBlocker.isStarted(powerSaveBlockerId)) {
                 if (payload.state === 'ended') {
                     powerSaveBlocker.stop(powerSaveBlockerId);
+                    powerSaveBlockerId = null;
                 }
             } else {
-                if (payload.state === 'connected') {
+                if (powerSaveBlockerId === null && payload.state === 'connected') {
                     powerSaveBlockerId = powerSaveBlocker.start('prevent-display-sleep');
                 }
             }


### PR DESCRIPTION
Calls often transition from connected to connected after transitioning
into the connected state (when the ICE layer connects) so we ended up
creating two wake locks and then only stopping one of them.

Don't make another wake lock if we already have one.

Hopefully fixes https://github.com/vector-im/riot-web/issues/6814