### PR TITLE
Remove the 'auto hide menu bar' option on Mac

### DIFF
--- a/src/vector/platform/ElectronPlatform.js
+++ b/src/vector/platform/ElectronPlatform.js
@@ -200,7 +200,8 @@ export default class ElectronPlatform extends VectorBasePlatform {
     }
 
     supportsAutoHideMenuBar(): boolean {
-        return true;
+        // This is irelevant on Mac as Menu bars don't live in the app window
+        return !navigator.platform.toUpperCase().includes('MAC');
     }
 
     async getAutoHideMenuBarEnabled(): boolean {


### PR DESCRIPTION
The menu bar is at the top of the screen on Mac so this setting
does absolutely nothing.

Option added in https://github.com/vector-im/riot-web/pull/10503