### PR TITLE
Let the user's homeserver config override the build config

### DIFF
--- a/electron_app/src/electron-main.js
+++ b/electron_app/src/electron-main.js
@@ -77,6 +77,18 @@ try {
 try {
     // Load local config and use it to override values from the one baked with the build
     const localConfig = require(path.join(app.getPath('userData'), 'config.json'));
+
+    // If the local config has a homeserver defined, don't use the homeserver from the build
+    // config. This is to avoid a problem where Riot thinks there are multiple homeservers
+    // defined, and panics as a result.
+    const homeserverProps = ['default_is_url', 'default_hs_url', 'default_server_name', 'default_server_config'];
+    if (Object.keys(localConfig).find(k => homeserverProps.includes(k))) {
+        // Rip out all the homeserver options from the vector config
+        vectorConfig = Object.keys(vectorConfig)
+            .filter(k => !homeserverProps.includes(k))
+            .reduce((obj, key) => {obj[key] = vectorConfig[key]; return obj;}, {});
+    }
+
     vectorConfig = Object.assign(vectorConfig, localConfig);
 } catch (e) {
     // Could not load local config, this is expected in most cases.


### PR DESCRIPTION
Specifically for the desktop app to prevent the warning about too many homeservers defined.