### PR TITLE
Use new theme API in react-sdk

### DIFF
--- a/src/vector/index.js
+++ b/src/vector/index.js
@@ -57,7 +57,7 @@ import WebPlatform from './platform/WebPlatform';
 import MatrixClientPeg from 'matrix-react-sdk/lib/MatrixClientPeg';
 import SettingsStore from "matrix-react-sdk/lib/settings/SettingsStore";
 import SdkConfig from "matrix-react-sdk/lib/SdkConfig";
-import {getBaseTheme, setTheme} from "matrix-react-sdk/lib/theme";
+import {getBaseTheme, setTheme, ThemeWatcher} from "matrix-react-sdk/lib/theme";
 
 import Olm from 'olm';
 
@@ -258,7 +258,8 @@ async function loadApp() {
     // we do this by checking to see if the theme's "base" has loaded first so we can
     // safely rely on the assets.
     let a;
-    const theme = SettingsStore.getValue("theme");
+    const themeWatcher = new ThemeWatcher();
+    const theme = themeWatcher.getEffectiveTheme();
     const baseTheme = getBaseTheme(theme);
     for (let i = 0; (a = document.getElementsByTagName("link")[i]); i++) {
         const href = a.getAttribute("href");


### PR DESCRIPTION
A thesis presented in two parts. This part has the absolute minimum
logic changes to the themeing code in vector/index.js because I know
how subtle and fragile this code is. However, it also looks like it's
completely duplicated from react-sdk, so in the next part I'm going
to remove that logic and make it use the logic in react-sdk, then we
can see what breaks.

Requires https://github.com/matrix-org/matrix-react-sdk/pull/3637