### PR TITLE
Sign all of the Windows executable files

### DIFF
--- a/package.json
+++ b/package.json
@@ -185,7 +185,8 @@
     "win": {
       "target": {
         "target": "squirrel"
-      }
+      },
+      "sign": "scripts/electron_winSign"
     },
     "directories": {
       "buildResources": "electron_app/build",

--- a/scripts/electron_afterSign.js
+++ b/scripts/electron_afterSign.js
@@ -1,7 +1,4 @@
 const { notarize } = require('electron-notarize');
-const { exec, execFile } = require('child_process');
-const fs = require('fs');
-const shellescape = require('shell-escape');
 
 exports.default = async function(context) {
     const { electronPlatformName, appOutDir } = context;
@@ -22,55 +19,6 @@ exports.default = async function(context) {
             appPath: `${appOutDir}/${appName}.app`,
             appleId: userId,
             appleIdPassword: '@keychain:NOTARIZE_CREDS',
-        });
-    } else if (electronPlatformName === 'win32') {
-        // This signs the actual Riot executable
-        const appName = context.packager.appInfo.productFilename;
-
-        // get the token passphrase from the keychain
-        const tokenPassphrase = await new Promise((resolve, reject) => {
-            execFile(
-                'security',
-                ['find-generic-password', '-s', 'riot_signing_token', '-w'],
-                {},
-                (err, stdout) => {
-                    if (err) {
-                        reject(err);
-                    } else {
-                        resolve(stdout.trim());
-                    }
-                },
-            );
-        });
-
-        return new Promise((resolve, reject) => {
-            let cmdLine = 'osslsigncode sign ';
-            if (process.env.OSSLSIGNCODE_SIGNARGS) {
-                cmdLine += process.env.OSSLSIGNCODE_SIGNARGS + ' ';
-            }
-            const tmpFile = 'tmp_' + Math.random().toString(36).substring(2, 15) + '.exe';
-            cmdLine += shellescape([
-                '-pass', tokenPassphrase,
-                '-in', `${appOutDir}/${appName}.exe`,
-                '-out', `${appOutDir}/${tmpFile}`,
-            ]);
-
-            const signproc = exec(cmdLine, {}, (error, stdout) => {
-                console.log(stdout);
-            });
-            signproc.on('exit', (code) => {
-                if (code !== 0) {
-                    reject("osslsigncode failed with code " + code);
-                    return;
-                }
-                fs.rename(`${appOutDir}/${tmpFile}`, `${appOutDir}/${appName}.exe`, (err) => {
-                    if (err) {
-                        reject(err);
-                    } else {
-                        resolve();
-                    }
-                });
-            });
         });
     }
 };

--- a/scripts/electron_winSign.js
+++ b/scripts/electron_winSign.js
@@ -1,0 +1,66 @@
+const { exec, execFile } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const shellescape = require('shell-escape');
+
+exports.default = async function(options) {
+    const inPath = options.path;
+    const appOutDir = path.dirname(inPath);
+
+    // get the token passphrase from the keychain
+    const tokenPassphrase = await new Promise((resolve, reject) => {
+        execFile(
+            'security',
+            ['find-generic-password', '-s', 'riot_signing_token', '-w'],
+            {},
+            (err, stdout) => {
+                if (err) {
+                    console.error("Couldn't find signing token in keychain", err);
+                    // electron-builder seems to print '[object Object]' on the
+                    // console whether you reject with an Error or a string...
+                    reject(err);
+                } else {
+                    resolve(stdout.trim());
+                }
+            },
+        );
+    });
+
+    return new Promise((resolve, reject) => {
+        let cmdLine = 'osslsigncode sign ';
+        if (process.env.OSSLSIGNCODE_SIGNARGS) {
+            cmdLine += process.env.OSSLSIGNCODE_SIGNARGS + ' ';
+        }
+        const tmpFile = path.join(
+            appOutDir,
+            'tmp_' + Math.random().toString(36).substring(2, 15) + '.exe',
+        );
+        const args = [
+            '-hash', options.hash,
+            '-pass', tokenPassphrase,
+            '-in', inPath,
+            '-out', tmpFile,
+        ];
+        if (options.isNest) args.push('-nest');
+        cmdLine += shellescape(args);
+
+        const signproc = exec(cmdLine, {}, (error, stdout) => {
+            console.log(stdout);
+        });
+        signproc.on('exit', (code) => {
+            if (code !== 0) {
+                console.error("osslsigncode failed with code " + code);
+                reject("osslsigncode failed with code " + code);
+                return;
+            }
+            fs.rename(tmpFile, inPath, (err) => {
+                if (err) {
+                    console.error("Error renaming file", err);
+                    reject(err);
+                } else {
+                    resolve();
+                }
+            });
+        });
+    });
+};


### PR DESCRIPTION
We can actually just supply a custom signing module here to do our
signing rather than manually signing things in the afterSign hook.
This means all 4 executable files get signed (the main exe, the
stub exe, Update.exe and the installer).