### PR TITLE
ElectronPlatform: Add the indexSize method.

### DIFF
--- a/electron_app/src/electron-main.js
+++ b/electron_app/src/electron-main.js
@@ -381,6 +381,17 @@ ipcMain.on('seshat', async function(ev, payload) {
             }
             break;
 
+        case 'indexSize':
+            if (eventIndex === null) ret = 0;
+            else {
+                try {
+                    ret = await eventIndex.getSize();
+                } catch (e) {
+                    ret = 0;
+                }
+            }
+            break;
+
         default:
             mainWindow.webContents.send('seshatReply', {
                 id: payload.id,

--- a/electron_app/src/electron-main.js
+++ b/electron_app/src/electron-main.js
@@ -346,6 +346,18 @@ ipcMain.on('seshat', async function(ev, payload) {
             }
             break;
 
+        case 'getStats':
+            if (eventIndex === null) ret = 0;
+            else {
+                try {
+                    ret = await eventIndex.getStats();
+                } catch (e) {
+                    sendError(payload.id, e);
+                    return;
+                }
+            }
+            break;
+
         case 'removeCrawlerCheckpoint':
             if (eventIndex === null) ret = false;
             else {
@@ -377,17 +389,6 @@ ipcMain.on('seshat', async function(ev, payload) {
                     ret = await eventIndex.loadCheckpoints();
                 } catch (e) {
                     ret = [];
-                }
-            }
-            break;
-
-        case 'indexSize':
-            if (eventIndex === null) ret = 0;
-            else {
-                try {
-                    ret = await eventIndex.getSize();
-                } catch (e) {
-                    ret = 0;
                 }
             }
             break;

--- a/src/vector/platform/ElectronPlatform.js
+++ b/src/vector/platform/ElectronPlatform.js
@@ -155,6 +155,10 @@ class SeshatIndexManager extends BaseEventIndexManager {
     async deleteEventIndex(): Promise<> {
         return this._ipcCall('deleteEventIndex');
     }
+
+    async indexSize(): Promise<> {
+        return this._ipcCall('indexSize');
+    }
 }
 
 export default class ElectronPlatform extends VectorBasePlatform {

--- a/src/vector/platform/ElectronPlatform.js
+++ b/src/vector/platform/ElectronPlatform.js
@@ -152,12 +152,12 @@ class SeshatIndexManager extends BaseEventIndexManager {
         return this._ipcCall('closeEventIndex');
     }
 
-    async deleteEventIndex(): Promise<> {
-        return this._ipcCall('deleteEventIndex');
+    async getStats(): Promise<> {
+        return this._ipcCall('getStats');
     }
 
-    async indexSize(): Promise<> {
-        return this._ipcCall('indexSize');
+    async deleteEventIndex(): Promise<> {
+        return this._ipcCall('deleteEventIndex');
     }
 }
 


### PR DESCRIPTION
This is the Riot side of patches for the event indexer UI, react-sdk side can be found here https://github.com/matrix-org/matrix-react-sdk/pull/3672. 

It only implements a method to get the index disk usage which we plan on presenting to users.

Part of https://github.com/vector-im/riot-web/issues/11984