### PR TITLE
Update riot.im enable_presence_by_hs_url for new matrix.org client URL

### DIFF
--- a/config.sample.json
+++ b/config.sample.json
@@ -47,7 +47,8 @@
         "siteId": 1
     },
     "enable_presence_by_hs_url": {
-        "https://matrix.org": false
+        "https://matrix.org": false,
+        "https://matrix-client.matrix.org": false
     },
     "settingDefaults": {
         "breadcrumbs": true

--- a/electron_app/riot.im/config.json
+++ b/electron_app/riot.im/config.json
@@ -34,6 +34,7 @@
         "feature_lazyloading": "enable"
     },
     "enable_presence_by_hs_url": {
-        "https://matrix.org": false
+        "https://matrix.org": false,
+        "https://matrix-client.matrix.org": false
     }
 }

--- a/riot.im/app/config.json
+++ b/riot.im/app/config.json
@@ -26,7 +26,8 @@
         ]
     },
     "enable_presence_by_hs_url": {
-        "https://matrix.org": false
+        "https://matrix.org": false,
+        "https://matrix-client.matrix.org": false
     },
     "terms_and_conditions_links": [
         {

--- a/riot.im/develop/config.json
+++ b/riot.im/develop/config.json
@@ -35,7 +35,8 @@
         ]
     },
     "enable_presence_by_hs_url": {
-        "https://matrix.org": false
+        "https://matrix.org": false,
+        "https://matrix-client.matrix.org": false
     },
     "terms_and_conditions_links": [
         {


### PR DESCRIPTION
Ideally you would update enable_presence_by_hs_url work based on the homeserver name instead of the client URL but this is a quick fix

Fixes #11564