### PR TITLE
Fix Docker build for develop and publish a /version file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,4 @@
 # Exclude a bunch of stuff which can make the build context a larger than it needs to be
-.git/
 test/
 webapp/
 lib/

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,9 @@ RUN yarn build
 # Copy the config now so that we don't create another layer in the app image
 RUN cp /src/config.sample.json /src/webapp/config.json
 
+# Ensure we populate the version file
+RUN dos2unix /src/scripts/docker-write-version.sh && sh /src/scripts/docker-write-version.sh
+
 
 # App
 FROM nginx:alpine

--- a/scripts/docker-link-repos.sh
+++ b/scripts/docker-link-repos.sh
@@ -2,6 +2,17 @@
 
 set -ex
 
+# Automatically link to develop if we're building develop, but only if the caller
+# hasn't asked us to build something else
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [ $USE_CUSTOM_SDKS == false ] && [ $BRANCH == 'develop' ]
+then
+    echo "using develop dependencies for react-sdk and js-sdk"
+    USE_CUSTOM_SDKS=true
+    JS_SDK_BRANCH='develop'
+    REACT_SDK_BRANCH='develop'
+fi
+
 if [ $USE_CUSTOM_SDKS == false ]
 then
     echo "skipping react-sdk and js-sdk installs: USE_CUSTOM_SDKS is false"

--- a/scripts/docker-write-version.sh
+++ b/scripts/docker-write-version.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+set -ex
+
+TAG=$(git describe --dirty --tags)
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+DIST_VERSION=$TAG
+
+# If the branch comes out as HEAD then we're probably checked out to a tag, so if the thing is *not*
+# coming out as HEAD then we're on a branch. When we're on a branch, we want to resolve ourselves to
+# a few SHAs rather than a version.
+if [ $BRANCH != 'HEAD' ]
+then
+    REACT_SHA=$(cd node_modules/matrix-react-sdk; git rev-parse --short=12 HEAD)
+    JSSDK_SHA=$(cd node_modules/matrix-js-sdk; git rev-parse --short=12 HEAD)
+    VECTOR_SHA=$(git rev-parse --short=12 HEAD) # use the ACTUAL SHA rather than assume develop
+    DIST_VERSION=$VECTOR_SHA-react-$REACT_SHA-js-$JSSDK_SHA
+fi
+
+echo $DIST_VERSION > /src/webapp/version


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/10426

The problem with the docker image for develop was that the dependencies pointing at develop are empirically not working - it's pulling in the latest release still even though we are saying to use the develop branch. To fix this, we just pull in develop by default if we're building develop.