### PR TITLE
Enable more languages

### DIFF
--- a/scripts/copy-res.js
+++ b/scripts/copy-res.js
@@ -25,10 +25,13 @@ const INCLUDE_LANGS = [
     {'value': 'fi', 'label': 'Suomi'},
     {'value': 'fr', 'label': 'Français'},
     {'value': 'gl', 'label': 'Galego'},
+    {'value': 'hi', 'label': 'हिन्दी'},
     {'value': 'hu', 'label': 'Magyar'},
+    {'value': 'is', 'label': 'Íslensku'},
     {'value': 'it', 'label': 'Italiano'},
     {'value': 'ja', 'label': '日本語'},
     {'value': 'ko', 'label': '한국어'},
+    {'value': 'lt', 'label': 'Lietuvis'},
     {'value': 'lv', 'label': 'Latviešu'},
     {'value': 'nb_NO', 'label': 'Norwegian Bokmål'},
     {'value': 'nl', 'label': 'Nederlands'},
@@ -44,6 +47,7 @@ const INCLUDE_LANGS = [
     {'value': 'te', 'label': 'తెలుగు'},
     {'value': 'th', 'label': 'ไทย'},
     {'value': 'tr', 'label': 'Türkçe'},
+    {'value': 'uk', 'label': 'Українська'},
     {'value': 'vls', 'label': 'West-Vlaams'},
     {'value': 'zh_Hans', 'label': '简体中文'}, // simplified chinese
     {'value': 'zh_Hant', 'label': '繁體中文'}, // traditional chinese

--- a/scripts/copy-res.js
+++ b/scripts/copy-res.js
@@ -27,11 +27,11 @@ const INCLUDE_LANGS = [
     {'value': 'gl', 'label': 'Galego'},
     {'value': 'hi', 'label': 'हिन्दी'},
     {'value': 'hu', 'label': 'Magyar'},
-    {'value': 'is', 'label': 'Íslensku'},
+    {'value': 'is', 'label': 'íslenska'},
     {'value': 'it', 'label': 'Italiano'},
     {'value': 'ja', 'label': '日本語'},
     {'value': 'ko', 'label': '한국어'},
-    {'value': 'lt', 'label': 'Lietuvis'},
+    {'value': 'lt', 'label': 'lietuvių kalba'},
     {'value': 'lv', 'label': 'Latviešu'},
     {'value': 'nb_NO', 'label': 'Norwegian Bokmål'},
     {'value': 'nl', 'label': 'Nederlands'},
@@ -47,7 +47,7 @@ const INCLUDE_LANGS = [
     {'value': 'te', 'label': 'తెలుగు'},
     {'value': 'th', 'label': 'ไทย'},
     {'value': 'tr', 'label': 'Türkçe'},
-    {'value': 'uk', 'label': 'Українська'},
+    {'value': 'uk', 'label': 'українська мова'},
     {'value': 'vls', 'label': 'West-Vlaams'},
     {'value': 'zh_Hans', 'label': '简体中文'}, // simplified chinese
     {'value': 'zh_Hant', 'label': '繁體中文'}, // traditional chinese


### PR DESCRIPTION
Enabled (riot-web % / react-sdk %):
* Lithuanian: 100% / 48.1% translated
* Hindi: 69.6% / 36.5% translated
* Ukrainian: 100% / 28.5% translated
* Icelandic: 43.5% / 27.7% translated

They aren't the highest languages, but they are more than our lowest translated & enabled languages.