### PR TITLE
Remove now-retired package.json property

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "webpack.config.js"
   ],
   "style": "bundle.css",
-  "matrix-react-parent": "matrix-react-sdk",
   "scripts": {
     "reskindex": "reskindex -h src/header",
     "reskindex:watch": "reskindex -h src/header -w",


### PR DESCRIPTION
For https://github.com/matrix-org/matrix-react-sdk/pull/3723

**Note: This is set to merge against `travis/sourcemaps` because it breaks things.**