### PR TITLE
electron-main: Provide a better error message if Seshat isn't installed.

### DIFF
--- a/electron_app/src/electron-main.js
+++ b/electron_app/src/electron-main.js
@@ -47,7 +47,11 @@ let Seshat = null;
 try {
     Seshat = require('matrix-seshat');
 } catch (e) {
-    console.warn("seshat unavailable", e);
+    if (e.code === "MODULE_NOT_FOUND") {
+        console.log("Seshat isn't installed, event indexing is disabled.");
+    } else {
+        console.warn("Seshat unexpected error:", e);
+    }
 }
 
 if (argv["help"]) {


### PR DESCRIPTION
This closes #11637.