### PR TITLE
Convert components to ES6 exports

### DIFF
--- a/electron_app/src/updater.js
+++ b/electron_app/src/updater.js
@@ -18,8 +18,7 @@ function pollForUpdates() {
     }
 }
 
-module.exports = {};
-module.exports.start = function startAutoUpdate(updateBaseUrl) {
+export function start(updateBaseUrl) {
     if (updateBaseUrl.slice(-1) !== '/') {
         updateBaseUrl = updateBaseUrl + '/';
     }

--- a/src/components/views/auth/VectorAuthFooter.js
+++ b/src/components/views/auth/VectorAuthFooter.js
@@ -20,7 +20,7 @@ import SdkConfig from 'matrix-react-sdk/lib/SdkConfig';
 
 import { _t } from 'matrix-react-sdk/lib/languageHandler';
 
-module.exports = () => {
+const VectorAuthFooter = () => {
     const brandingConfig = SdkConfig.get().branding;
     let links = [
         {"text": "blog", "url": "https://medium.com/@RiotChat"},
@@ -48,4 +48,7 @@ module.exports = () => {
         </div>
     );
 };
-module.exports.replaces = 'AuthFooter';
+
+VectorAuthFooter.replaces = 'AuthFooter';
+
+export default VectorAuthFooter;

--- a/src/components/views/auth/VectorCustomServerDialog.js
+++ b/src/components/views/auth/VectorCustomServerDialog.js
@@ -22,7 +22,7 @@ import { _t } from 'matrix-react-sdk/lib/languageHandler';
  * This is identical to `CustomServerDialog` except for replacing "this app"
  * with "Riot".
  */
-module.exports = ({onFinished}) => {
+const VectorCustomServerDialog = ({onFinished}) => {
     return (
         <div className="mx_ErrorDialog">
             <div className="mx_Dialog_title">
@@ -44,4 +44,7 @@ module.exports = ({onFinished}) => {
         </div>
     );
 };
-module.exports.replaces = 'CustomServerDialog';
+
+VectorCustomServerDialog.replaces = 'CustomServerDialog';
+
+export default VectorCustomServerDialog;


### PR DESCRIPTION
**This is against `travis/sourcemaps` for safety.**

Split from https://github.com/vector-im/riot-web/pull/11679

ES6 exports == happy development and webpack.

----

This PR and others in the series have their overview covered here: https://gist.github.com/turt2live/a3fc7c9712b8ef0f1f758611aa33382d