### PR TITLE
Import from src/ for the react-sdk and js-sdk

### DIFF
--- a/src/components/structures/VectorEmbeddedPage.js
+++ b/src/components/structures/VectorEmbeddedPage.js
@@ -18,9 +18,9 @@ limitations under the License.
 
 'use strict';
 
-import EmbeddedPage from 'matrix-react-sdk/lib/components/structures/EmbeddedPage';
+import EmbeddedPage from 'matrix-react-sdk/src/components/structures/EmbeddedPage';
 import sanitizeHtml from 'sanitize-html';
-import { _t } from 'matrix-react-sdk/lib/languageHandler';
+import { _t } from 'matrix-react-sdk/src/languageHandler';
 
 export default class VectorEmbeddedPage extends EmbeddedPage {
     static replaces = 'EmbeddedPage';

--- a/src/components/views/auth/VectorAuthFooter.js
+++ b/src/components/views/auth/VectorAuthFooter.js
@@ -16,9 +16,8 @@ limitations under the License.
 */
 
 import React from 'react';
-import SdkConfig from 'matrix-react-sdk/lib/SdkConfig';
-
-import { _t } from 'matrix-react-sdk/lib/languageHandler';
+import SdkConfig from 'matrix-react-sdk/src/SdkConfig';
+import { _t } from 'matrix-react-sdk/src/languageHandler';
 
 module.exports = () => {
     const brandingConfig = SdkConfig.get().branding;

--- a/src/components/views/auth/VectorAuthHeaderLogo.js
+++ b/src/components/views/auth/VectorAuthHeaderLogo.js
@@ -19,7 +19,7 @@ limitations under the License.
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import SdkConfig from 'matrix-react-sdk/lib/SdkConfig';
+import SdkConfig from 'matrix-react-sdk/src/SdkConfig';
 
 export default class VectorAuthHeaderLogo extends React.PureComponent {
     static replaces = 'AuthHeaderLogo'

--- a/src/components/views/auth/VectorAuthPage.js
+++ b/src/components/views/auth/VectorAuthPage.js
@@ -17,8 +17,8 @@ limitations under the License.
 'use strict';
 
 import React from 'react';
-import sdk from 'matrix-react-sdk/lib/index';
-import SdkConfig from 'matrix-react-sdk/lib/SdkConfig';
+import * as sdk from 'matrix-react-sdk/src/index';
+import SdkConfig from 'matrix-react-sdk/src/SdkConfig';
 
 export default class VectorAuthPage extends React.PureComponent {
     static replaces = 'AuthPage'

--- a/src/components/views/auth/VectorCustomServerDialog.js
+++ b/src/components/views/auth/VectorCustomServerDialog.js
@@ -16,7 +16,7 @@ limitations under the License.
 */
 
 import React from "react";
-import { _t } from 'matrix-react-sdk/lib/languageHandler';
+import { _t } from 'matrix-react-sdk/src/languageHandler';
 
 /**
  * This is identical to `CustomServerDialog` except for replacing "this app"

--- a/src/vector/index.js
+++ b/src/vector/index.js
@@ -35,15 +35,15 @@ global.React = React;
 
 import './modernizr';
 import ReactDOM from 'react-dom';
-import sdk from 'matrix-react-sdk';
-import PlatformPeg from 'matrix-react-sdk/lib/PlatformPeg';
+import * as sdk from 'matrix-react-sdk';
+import PlatformPeg from 'matrix-react-sdk/src/PlatformPeg';
 sdk.loadSkin(require('../component-index'));
-import VectorConferenceHandler from 'matrix-react-sdk/lib/VectorConferenceHandler';
-import * as languageHandler from 'matrix-react-sdk/lib/languageHandler';
-import {_t, _td, newTranslatableError} from 'matrix-react-sdk/lib/languageHandler';
-import AutoDiscoveryUtils from 'matrix-react-sdk/lib/utils/AutoDiscoveryUtils';
-import {AutoDiscovery} from "matrix-js-sdk/lib/autodiscovery";
-import * as Lifecycle from "matrix-react-sdk/lib/Lifecycle";
+import * as VectorConferenceHandler from 'matrix-react-sdk/src/VectorConferenceHandler';
+import * as languageHandler from 'matrix-react-sdk/src/languageHandler';
+import {_t, _td, newTranslatableError} from 'matrix-react-sdk/src/languageHandler';
+import AutoDiscoveryUtils from 'matrix-react-sdk/src/utils/AutoDiscoveryUtils';
+import {AutoDiscovery} from "matrix-js-sdk/src/autodiscovery";
+import * as Lifecycle from "matrix-react-sdk/src/Lifecycle";
 
 import url from 'url';
 
@@ -52,14 +52,14 @@ import {parseQs, parseQsFromFragment} from './url_utils';
 import ElectronPlatform from './platform/ElectronPlatform';
 import WebPlatform from './platform/WebPlatform';
 
-import MatrixClientPeg from 'matrix-react-sdk/lib/MatrixClientPeg';
-import SettingsStore from "matrix-react-sdk/lib/settings/SettingsStore";
-import SdkConfig from "matrix-react-sdk/lib/SdkConfig";
-import {setTheme} from "matrix-react-sdk/lib/theme";
+import {MatrixClientPeg} from 'matrix-react-sdk/src/MatrixClientPeg';
+import SettingsStore from "matrix-react-sdk/src/settings/SettingsStore";
+import SdkConfig from "matrix-react-sdk/src/SdkConfig";
+import {setTheme} from "matrix-react-sdk/src/theme";
 
 import Olm from 'olm';
 
-import CallHandler from 'matrix-react-sdk/lib/CallHandler';
+import CallHandler from 'matrix-react-sdk/src/CallHandler';
 
 let lastLocationHashSet = null;
 

--- a/src/vector/indexeddb-worker.js
+++ b/src/vector/indexeddb-worker.js
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import {IndexedDBStoreWorker} from 'matrix-js-sdk/lib/indexeddb-worker.js';
+import {IndexedDBStoreWorker} from 'matrix-js-sdk/src/indexeddb-worker.js';
 
 const remoteWorker = new IndexedDBStoreWorker(postMessage);
 

--- a/src/vector/platform/ElectronPlatform.js
+++ b/src/vector/platform/ElectronPlatform.js
@@ -20,10 +20,10 @@ limitations under the License.
 */
 
 import VectorBasePlatform, {updateCheckStatusEnum} from './VectorBasePlatform';
-import BaseEventIndexManager from 'matrix-react-sdk/lib/indexing/BaseEventIndexManager';
-import dis from 'matrix-react-sdk/lib/dispatcher';
-import { _t } from 'matrix-react-sdk/lib/languageHandler';
-import rageshake from 'matrix-react-sdk/lib/rageshake/rageshake';
+import BaseEventIndexManager from 'matrix-react-sdk/src/indexing/BaseEventIndexManager';
+import dis from 'matrix-react-sdk/src/dispatcher';
+import { _t } from 'matrix-react-sdk/src/languageHandler';
+import * as rageshake from 'matrix-react-sdk/src/rageshake/rageshake';
 
 const ipcRenderer = window.ipcRenderer;
 

--- a/src/vector/platform/VectorBasePlatform.js
+++ b/src/vector/platform/VectorBasePlatform.js
@@ -19,9 +19,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import BasePlatform from 'matrix-react-sdk/lib/BasePlatform';
-import { _t } from 'matrix-react-sdk/lib/languageHandler';
-import dis from 'matrix-react-sdk/lib/dispatcher';
+import BasePlatform from 'matrix-react-sdk/src/BasePlatform';
+import { _t } from 'matrix-react-sdk/src/languageHandler';
+import dis from 'matrix-react-sdk/src/dispatcher';
 import {getVectorConfig} from "../getconfig";
 
 import Favico from 'favico.js';

--- a/src/vector/platform/WebPlatform.js
+++ b/src/vector/platform/WebPlatform.js
@@ -19,8 +19,8 @@ limitations under the License.
 
 import VectorBasePlatform, {updateCheckStatusEnum} from './VectorBasePlatform';
 import request from 'browser-request';
-import dis from 'matrix-react-sdk/lib/dispatcher.js';
-import { _t } from 'matrix-react-sdk/lib/languageHandler';
+import dis from 'matrix-react-sdk/src/dispatcher.js';
+import { _t } from 'matrix-react-sdk/src/languageHandler';
 
 import url from 'url';
 import UAParser from 'ua-parser-js';

--- a/src/vector/rageshakesetup.js
+++ b/src/vector/rageshakesetup.js
@@ -25,8 +25,8 @@ limitations under the License.
  * from the rageshake.)
  */
 
-import rageshake from "matrix-react-sdk/lib/rageshake/rageshake";
-import SdkConfig from "matrix-react-sdk/lib/SdkConfig";
+import * as rageshake from "matrix-react-sdk/src/rageshake/rageshake";
+import SdkConfig from "matrix-react-sdk/src/SdkConfig";
 
 function initRageshake() {
     rageshake.init().then(() => {
@@ -54,7 +54,7 @@ global.mxSendRageshake = function(text, withLogs) {
         console.error("Cannot send a rageshake without a message - please tell us what went wrong");
         return;
     }
-    require(['matrix-react-sdk/lib/rageshake/submit-rageshake'], (s) => {
+    require(['matrix-react-sdk/src/rageshake/submit-rageshake'], (s) => {
         s(SdkConfig.get().bug_report_endpoint_url, {
             userText: text,
             sendLogs: withLogs,

--- a/test/app-tests/joining.js
+++ b/test/app-tests/joining.js
@@ -16,7 +16,7 @@ limitations under the License.
 
 /* joining.js: tests for the various paths when joining a room */
 
-import PlatformPeg from 'matrix-react-sdk/lib/PlatformPeg';
+import PlatformPeg from 'matrix-react-sdk/src/PlatformPeg';
 import WebPlatform from '../../src/vector/platform/WebPlatform';
 
 require('skin-sdk');
@@ -33,8 +33,8 @@ const React = require('react');
 const ReactDOM = require('react-dom');
 const ReactTestUtils = require('react-dom/test-utils');
 const expect = require('expect');
-import {makeType} from "matrix-react-sdk/lib/utils/TypeUtils";
-import {ValidatedServerConfig} from "matrix-react-sdk/lib/utils/AutoDiscoveryUtils";
+import {makeType} from "matrix-react-sdk/src/utils/TypeUtils";
+import {ValidatedServerConfig} from "matrix-react-sdk/src/utils/AutoDiscoveryUtils";
 import {sleep} from "../test-utils";
 
 const test_utils = require('../test-utils');

--- a/test/app-tests/loading.js
+++ b/test/app-tests/loading.js
@@ -16,7 +16,7 @@ limitations under the License.
 
 /* loading.js: test the myriad paths we have for loading the application */
 
-import PlatformPeg from 'matrix-react-sdk/lib/PlatformPeg';
+import PlatformPeg from 'matrix-react-sdk/src/PlatformPeg';
 import WebPlatform from '../../src/vector/platform/WebPlatform';
 
 import 'skin-sdk';
@@ -30,16 +30,16 @@ import MatrixReactTestUtils from 'matrix-react-test-utils';
 import jssdk from 'matrix-js-sdk';
 
 import sdk from 'matrix-react-sdk';
-import MatrixClientPeg from 'matrix-react-sdk/lib/MatrixClientPeg';
-import * as languageHandler from 'matrix-react-sdk/lib/languageHandler';
-import {VIEWS} from 'matrix-react-sdk/lib/components/structures/MatrixChat';
-import dis from 'matrix-react-sdk/lib/dispatcher';
+import {MatrixClientPeg} from 'matrix-react-sdk/src/MatrixClientPeg';
+import * as languageHandler from 'matrix-react-sdk/src/languageHandler';
+import {VIEWS} from 'matrix-react-sdk/src/components/structures/MatrixChat';
+import dis from 'matrix-react-sdk/src/dispatcher';
 
 import * as test_utils from '../test-utils';
 import MockHttpBackend from 'matrix-mock-request';
 import {parseQs, parseQsFromFragment} from '../../src/vector/url_utils';
-import {makeType} from "matrix-react-sdk/lib/utils/TypeUtils";
-import {ValidatedServerConfig} from "matrix-react-sdk/lib/utils/AutoDiscoveryUtils";
+import {makeType} from "matrix-react-sdk/src/utils/TypeUtils";
+import {ValidatedServerConfig} from "matrix-react-sdk/src/utils/AutoDiscoveryUtils";
 import {sleep} from "../test-utils";
 
 const DEFAULT_HS_URL='http://my_server';


### PR DESCRIPTION
**This is against `travis/sourcemaps` for safety.**

Split from https://github.com/vector-im/riot-web/pull/11679

We compile directly for accuracy of sourcemaps.

----

This PR and others in the series have their overview covered here: https://gist.github.com/turt2live/a3fc7c9712b8ef0f1f758611aa33382d