### PR TITLE
Updated blog url

### DIFF
--- a/src/components/views/auth/VectorAuthFooter.js
+++ b/src/components/views/auth/VectorAuthFooter.js
@@ -23,7 +23,7 @@ import { _t } from 'matrix-react-sdk/lib/languageHandler';
 module.exports = () => {
     const brandingConfig = SdkConfig.get().branding;
     let links = [
-        {"text": "blog", "url": "https://medium.com/@RiotChat"},
+        {"text": "blog", "url": "https://blog.riot.im"},
         {"text": "twitter", "url": "https://twitter.com/@RiotChat"},
         {"text": "github", "url": "https://github.com/vector-im/riot-web"},
     ];


### PR DESCRIPTION
The blog url was pointing to medium.com, where the top post said you are now using https://blog.riot.im/ so I propose to update the url in the app as well if this is correct.