### PR TITLE
Move build:genfiles step into test script

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -45,7 +45,6 @@ steps:
       - "echo '--- Fetching Dependencies'"
       - "./scripts/fetch-develop.deps.sh --depth 1"
       - "yarn install"
-      - "yarn build:genfiles"  # We have to build the app to make sure the autogenned files are present
       - "echo '+++ Running Tests'"
       - "yarn test"
     plugins:

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "lint:ts": "echo 'We don't actually have a typescript linter at this layer because tslint is being removed from our stack. Presumably your TS is fine.'",
     "lint:types": "tsc --noEmit",
     "lint:style": "stylelint 'res/css/**/*.scss'",
-    "test": "jest"
+    "test": "yarn build:genfiles && jest"
   },
   "dependencies": {
     "browser-request": "^0.3.3",


### PR DESCRIPTION
Developers will need to run both anyways, so might as well save them a headache.