### PR TITLE
Split vendor packages from bundle

### DIFF
--- a/src/vector/index.html
+++ b/src/vector/index.html
@@ -40,6 +40,7 @@
     <script>
         window.vector_indexeddb_worker_script = '<%= htmlWebpackPlugin.files.chunks['indexeddb-worker'].entry %>';
     </script>
+    <script src="<%= htmlWebpackPlugin.files.chunks['vendor'].entry %>"></script>
     <script src="<%= htmlWebpackPlugin.files.chunks['bundle'].entry %>"></script>
     <script>
       if ('serviceWorker' in navigator) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -54,6 +54,30 @@ module.exports = (env, argv) => {
                         enforce: true,
                         // Do not add `chunks: 'all'` here because you'll break the app entry point.
                     },
+                    vendor: {
+                        test: (mod) => {
+                            const nodeModules = path.join(__dirname, "node_modules");
+                            const reactSdk = path.join(nodeModules, "matrix-react-sdk");
+                            const jsSdk = path.join(nodeModules, "matrix-js-sdk");
+                            return mod && mod.resource && (
+                                // Required from the sdks (primarly for `develop`)
+                                mod.resource.includes(path.join(reactSdk, "node_modules")) ||
+                                mod.resource.includes(path.join(jsSdk, "node_modules")) ||
+                                // Directly required vendor libs
+                                (mod.resource.includes(nodeModules) && (
+                                    !mod.resource.includes(reactSdk) &&
+                                    !mod.resource.includes(jsSdk)
+                                ))
+                            );
+                        },
+                        name: 'vendor',
+                        enforce: true,
+                        chunks: (chunk) => {
+                            // exclude `indexeddb-worker` because it runs in a different context
+                            // and thus cannot know about vendor libs
+                            return chunk.name !== 'indexeddb-worker';
+                        },
+                    },
                 },
             },
 


### PR DESCRIPTION
This change splits all vendor packages located in node_modules into a separate `vendor.js` bundle. The `bundle.js` is currently over 4MB which prevents publishing [riot-webext](https://github.com/stoically/riot-webext) on [AMO](https://addons.mozilla.org/), since they impose a strict maximum file size of 4MB. With this change the `vendor.js` is about 3.5MB and the `bundle.js` is 2.2MB.

Another convenient benefit of this change is that riot web users won't have to download the whole bundle if just the riot web sources change but not the vendor packages.

Excluding of `indexeddb-worker` is required since the worker isn't aware of already "installed modules" (webpack lingo) because of different context.

Tested with Riot Web and Riot Desktop.