### PR TITLE
Update cookie policy urls on /app and /develop config.json

### DIFF
--- a/riot.im/app/config.json
+++ b/riot.im/app/config.json
@@ -18,7 +18,7 @@
     "piwik": {
         "url": "https://piwik.riot.im/",
         "siteId": 1,
-        "policyUrl": "https://matrix.org/docs/guides/riot_im_cookie_policy"
+        "policyUrl": "https://matrix.org/legal/riot-im-cookie-policy"
     },
     "roomDirectory": {
         "servers": [

--- a/riot.im/develop/config.json
+++ b/riot.im/develop/config.json
@@ -30,7 +30,7 @@
     "piwik": {
         "url": "https://piwik.riot.im/",
         "siteId": 1,
-        "policyUrl": "https://matrix.org/docs/guides/riot_im_cookie_policy"
+        "policyUrl": "https://matrix.org/legal/riot-im-cookie-policy"
     },
     "roomDirectory": {
         "servers": [


### PR DESCRIPTION
The old link redirected to the new one so there's no rush shipping these configs

Fixes https://github.com/vector-im/riot-web/issues/10362