### PR TITLE
Use debian to build the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Builder
-FROM node:10-alpine as builder
+FROM node:10 as builder
 
 # Support custom branches of the react-sdk and js-sdk. This also helps us build
 # images of riot-web develop.
@@ -9,7 +9,7 @@ ARG REACT_SDK_BRANCH="master"
 ARG JS_SDK_REPO="https://github.com/matrix-org/matrix-js-sdk.git"
 ARG JS_SDK_BRANCH="master"
 
-RUN apk add --no-cache git dos2unix
+RUN apt-get update && apt-get install -y git dos2unix
 
 WORKDIR /src
 


### PR DESCRIPTION
Fixes not having certain OS capabilities to build some packages.