### PR TITLE
Remove docs for new invite dialog labs feature

### DIFF
--- a/docs/labs.md
+++ b/docs/labs.md
@@ -82,12 +82,6 @@ that downloads, stores, and indexes room messages for E2E encrypted rooms.
 The existing search will transparently work for encrypted rooms just like it
 does for non-encrypted.
 
-## New invite dialog (`feature_ftue_dms`)
-
-An improved dialog for inviting users. This replaces both the DM creation dialog 
-and the 'invite user' dialog, using your recent DMs as a suggestion for who to chat
-with.
-
 ## Bridge info tab (`feature_bridge_state`)
 
 Adds a "Bridge Info" tab to the Room Settings dialog, if a compatible bridge is

--- a/riot.im/develop/config.json
+++ b/riot.im/develop/config.json
@@ -22,7 +22,6 @@
         "feature_dm_verification": "labs",
         "feature_cross_signing": "labs",
         "feature_event_indexing": "disable",
-        "feature_ftue_dms": "labs",
         "feature_bridge_state": "labs",
         "feature_presence_in_room_list": "labs"
     },


### PR DESCRIPTION
It's the default now: https://github.com/matrix-org/matrix-react-sdk/pull/3906

**Review with https://github.com/matrix-org/matrix-react-sdk/pull/3906**