### PR TITLE
Add top left menu shortcut

### DIFF
--- a/docs/shortcuts.md
+++ b/docs/shortcuts.md
@@ -11,3 +11,4 @@ The modifier is <kbd>Ctrl</kbd> on Windows & Linux and <kbd>⌘</kbd> on Mac.
 - <kbd>Alt</kbd>+<kbd>↑</kbd>/<kbd>↓</kbd> - resend previous messages when the composer is in focus
 - <kbd>PageUp</kbd>/<kbd>PageDown</kbd> - scroll timeline up/down
 - <kbd>Ctrl</kbd>/<kbd>⌘</kbd>+<kbd>Home</kbd>/<kbd>End</kbd> - jump to timeline start/end
+- <kbd>Ctrl</kbd>/<kbd>⌘</kbd>+<kbd>`</kbd> - toggle the top left menu


### PR DESCRIPTION
Add the one missing Ctrl+` shortcut to the list of shortcuts.