### PR TITLE
Automate SDK dep upgrades for release

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -24,13 +24,22 @@ do
     latestver=`yarn info -s $i dist-tags.next`
     if [ "$depver" != "$latestver" ]
     then
-        echo "The latest version of $i is $latestver but package.json depends on $depver"
-        echo -n "Type 'Yes' to continue anyway: "
+        echo "The latest version of $i is $latestver but package.json depends on $depver."
+        echo -n "Type 'u' to auto-upgrade, 'c' to continue anyway, or 'a' to abort:"
         read resp
-        if [ "$resp" != "Yes" ]
+        if [ "$resp" != "u" ] && [ "$resp" != "c" ]
         then
-            echo "OK, never mind."
+            echo "Aborting."
             exit 1
+        fi
+        if [ "$resp" == "u" ]
+        then
+            echo "Upgrading $i to $latestver..."
+            yarn add -E $i@$latestver
+            git add -u
+            # The `-e` flag opens the editor and gives you a chance to check
+            # the upgrade for correctness.
+            git commit -m "Upgrade $i to $latestver" -e
         fi
     fi
 done

--- a/release.sh
+++ b/release.sh
@@ -21,7 +21,7 @@ cd `dirname $0`
 for i in matrix-js-sdk matrix-react-sdk
 do
     depver=`cat package.json | jq -r .dependencies[\"$i\"]`
-    latestver=`yarn info -s $i version`
+    latestver=`yarn info -s $i dist-tags.next`
     if [ "$depver" != "$latestver" ]
     then
         echo "The latest version of $i is $latestver but package.json depends on $depver"

--- a/release.sh
+++ b/release.sh
@@ -44,11 +44,17 @@ do
     fi
 done
 
-# bump Electron's package.json first
 release="${1#v}"
 tag="v${release}"
-echo "electron yarn version"
+prerelease=0
+# We check if this build is a prerelease by looking to
+# see if the version has a hyphen in it. Crude,
+# but semver doesn't support postreleases so anything
+# with a hyphen is a prerelease.
+echo $release | grep -q '-' && prerelease=1
 
+# bump Electron's package.json first
+echo "electron yarn version"
 cd electron_app
 yarn version --no-git-tag-version --new-version "$release"
 git commit package.json -m "$tag"
@@ -56,3 +62,16 @@ git commit package.json -m "$tag"
 cd ..
 
 exec ./node_modules/matrix-js-sdk/release.sh -u vector-im -z "$orig_args"
+
+if [ $prerelease -eq 0 ]
+then
+    # For a release, reset SDK deps back to the `develop` branch.
+    for i in matrix-js-sdk matrix-react-sdk
+    do
+        echo "Resetting $i to develop branch..."
+        yarn add github:matrix-org/$i#develop
+        git add -u
+        git commit -m "Reset $i back to develop branch"
+    done
+    git push origin develop
+fi


### PR DESCRIPTION
This scripts the SDK dep handling to simplify the release process.

**Note:** Targetting the release branch.

See also https://github.com/matrix-org/matrix-react-sdk/pull/4076
See also https://github.com/matrix-org/matrix-js-sdk/pull/1212