### PR TITLE
Document start / end composer shortcuts

### DIFF
--- a/docs/shortcuts.md
+++ b/docs/shortcuts.md
@@ -10,5 +10,6 @@ The modifier is <kbd>Ctrl</kbd> on Windows & Linux and <kbd>⌘</kbd> on Mac.
 - <kbd>↑</kbd>/<kbd>↓</kbd> - next/prev room when focus in room list
 - <kbd>Alt</kbd>+<kbd>↑</kbd>/<kbd>↓</kbd> - resend previous messages when the composer is in focus
 - <kbd>PageUp</kbd>/<kbd>PageDown</kbd> - scroll timeline up/down
-- <kbd>Ctrl</kbd>/<kbd>⌘</kbd>+<kbd>Home</kbd>/<kbd>End</kbd> - jump to timeline start/end
+- <kbd>Ctrl</kbd>/<kbd>⌘</kbd>+<kbd>Home</kbd>/<kbd>End</kbd> - jump to
+  start/end of the composer when focused, otherwise jump to timeline start/end
 - <kbd>Ctrl</kbd>/<kbd>⌘</kbd>+<kbd>`</kbd> - toggle the top left menu


### PR DESCRIPTION
This documents shortcuts for jumping to the start / end of the composer
contents.

Part of https://github.com/vector-im/riot-web/issues/12438
Depends on https://github.com/matrix-org/matrix-react-sdk/pull/4108