### PR TITLE
Clarify supported tier means desktop OSes

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,10 @@ Riot has several tiers of support for different environments:
 
 * Supported
   * Definition: Issues **actively triaged**, regressions **block** the release
-  * Last 2 major versions of Chrome, Firefox, and Safari
-  * Latest release of official Riot Desktop app on macOS, Windows, and Linux versions that are actively supported by the OS vendor and receive security updates
+  * Last 2 major versions of Chrome, Firefox, and Safari on desktop OSes
+  * Latest release of official Riot Desktop app on desktop OSes
+  * Desktop OSes means macOS, Windows, and Linux versions for desktop devices
+    that are actively supported by the OS vendor and receive security updates
 * Experimental
   * Definition: Issues **accepted**, regressions **do not block** the release
   * Riot as an installed PWA via current stable version of Chrome, Firefox, and Safari


### PR DESCRIPTION
This clarifies that the "supported" tier is for browser and the official app on
desktop OSes only.

Fixes https://github.com/vector-im/riot-web/issues/12421