### PR TITLE
Relax macOS notarisation check to print a warning

### DIFF
--- a/scripts/electron_afterSign.js
+++ b/scripts/electron_afterSign.js
@@ -10,7 +10,10 @@ exports.default = async function(context) {
         // from the keychain, so we need to get it from the environment.
         const userId = process.env.NOTARIZE_APPLE_ID;
         if (userId === undefined) {
-            throw new Error("User ID not found. Set NOTARIZE_APPLE_ID.");
+            console.warn(
+                "Skipping notarisation: User ID not found, set NOTARIZE_APPLE_ID.",
+            );
+            return;
         }
 
         console.log("Notarising macOS app. This may be some time.");

--- a/scripts/electron_afterSign.js
+++ b/scripts/electron_afterSign.js
@@ -11,7 +11,9 @@ exports.default = async function(context) {
         const userId = process.env.NOTARIZE_APPLE_ID;
         if (userId === undefined) {
             console.warn(
-                "Skipping notarisation: User ID not found, set NOTARIZE_APPLE_ID.",
+                "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n" +
+                "! Skipping notarisation: User ID not found, set NOTARIZE_APPLE_ID. !\n" +
+                "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!",
             );
             return;
         }


### PR DESCRIPTION
This makes it a bit more friendly to build macOS Electron builds without a
notarisation config set up by only warning when it is missing.