### PR TITLE
Remove will-navigate comment after Electron fix

### DIFF
--- a/electron_app/src/webcontents-handler.js
+++ b/electron_app/src/webcontents-handler.js
@@ -174,18 +174,6 @@ function onEditableContextMenu(ev, params) {
 
 module.exports = (webContents) => {
     webContents.on('new-window', onWindowOrNavigate);
-    // XXX: The below now does absolutely nothing because of
-    // https://github.com/electron/electron/issues/8841
-    // Whilst this isn't a security issue since without
-    // node integration and with the sandbox, it should be
-    // no worse than opening the site in Chrome, it obviously
-    // means the user has to restart Riot to make it usable
-    // again (often unintuitive because it minimises to the
-    // system tray). We therefore need to be vigilant about
-    // putting target="_blank" on links in Riot (although
-    // we should generally be doing this anyway since links
-    // navigating you away from Riot in the browser is
-    // also annoying).
     webContents.on('will-navigate', onWindowOrNavigate);
 
     webContents.on('context-menu', function(ev, params) {


### PR DESCRIPTION
Electron 8.0.2 and later (which we're now using) resolves this issue with
`will-navigate`.