### PR TITLE
Fix SSO flows for electron 8.0.2 by re-breaking will-navigate

### DIFF
--- a/electron_app/src/webcontents-handler.js
+++ b/electron_app/src/webcontents-handler.js
@@ -174,7 +174,8 @@ function onEditableContextMenu(ev, params) {
 
 module.exports = (webContents) => {
     webContents.on('new-window', onWindowOrNavigate);
-    webContents.on('will-navigate', onWindowOrNavigate);
+    // XXX: https://github.com/vector-im/riot-web/issues/8247
+    // webContents.on('will-navigate', onWindowOrNavigate);
 
     webContents.on('context-menu', function(ev, params) {
         if (params.linkURL || params.srcURL) {


### PR DESCRIPTION
Stopgap solution until we switch to riot-desktop in 1.6 which will have a `riot://` protocol handler, see https://github.com/vector-im/riot-web/issues/8247

Electron 8.0.2 fixed will-navigate in sandboxed windows, we assumed it was broken, now we need it to stay that way.