### PR TITLE
Updates for Seshat 1.2.0 (not released yet) and reindexing.

### DIFF
--- a/electron_app/src/electron-main.js
+++ b/electron_app/src/electron-main.js
@@ -43,10 +43,19 @@ const Store = require('electron-store');
 const fs = require('fs');
 const afs = fs.promises;
 
-let Seshat = null;
+let seshatSupported = false;
+let Seshat;
+let SeshatRecovery;
+let ReindexError;
+
+const seshatPassphrase = "DEFAULT_PASSPHRASE";
 
 try {
-    Seshat = require('matrix-seshat');
+    seshatModule = require('matrix-seshat');
+    Seshat = seshatModule.Seshat;
+    SeshatRecovery = seshatModule.SeshatRecovery;
+    ReindexError = seshatModule.ReindexError;
+    seshatSupported = true;
 } catch (e) {
     if (e.code === "MODULE_NOT_FOUND") {
         console.log("Seshat isn't installed, event indexing is disabled.");
@@ -267,18 +276,36 @@ ipcMain.on('seshat', async function(ev, payload) {
 
     switch (payload.name) {
         case 'supportsEventIndexing':
-            if (Seshat === null) ret = false;
-            else ret = true;
+            ret = seshatSupported;
             break;
 
         case 'initEventIndex':
             if (eventIndex === null) {
                 try {
                     await afs.mkdir(eventStorePath, {recursive: true});
-                    eventIndex = new Seshat(eventStorePath, {passphrase: "DEFAULT_PASSPHRASE"});
+                    eventIndex = new Seshat(eventStorePath, {passphrase: seshatPassphrase});
                 } catch (e) {
-                    sendError(payload.id, e);
-                    return;
+                    if (e instanceof ReindexError) {
+                        // If this is a reindex error, the index schema
+                        // changed. Try to open the database in recovery mode,
+                        // reindex the database and finally try to open the
+                        // database again.
+                        try {
+                            recoveryIndex = new SeshatRecovery(eventStorePath,
+                                                               {passphrase: seshatPassphrase});
+                            await recoveryIndex.reindex();
+                            // Delete the recovery index here to make sure that
+                            // the locks are freed.
+                            delete recoveryIndex;
+                            eventIndex = new Seshat(eventStorePath, {passphrase: seshatPassphrase});
+                        } catch (e) {
+                            sendError(payload.id, e);
+                            return;
+                        }
+                    } else {
+                        sendError(payload.id, e);
+                        return;
+                    }
                 }
             }
             break;


### PR DESCRIPTION
Since Seshat 1.2.0 will have multiple classes exported some minor changes to our imports are needed, reindexing a database that fails to open because one is needed is also handled here.

The reindex is needed because our index schema was changed, later on reindexing will be needed if we introduce language settings for the index, for those we will want to expose an UI showing the progress of the reindex.

If this turns out to be slow we might want to do it for this type of reindex as well. A reindex on a 3k event large database did not show any noticeable start up lag.

Do note, that we'll want to merge this once a new Seshat release is out.