### PR TITLE
Update electron to v7.1.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
   },
   "build": {
     "appId": "im.riot.app",
-    "electronVersion": "7.1.12",
+    "electronVersion": "7.1.14",
     "files": [
       "node_modules/**",
       "src/**"


### PR DESCRIPTION
Update dependency to electron version 7.1.14 to resolve issue where riot-web
has troubles syncing messages, and throws a "**CRASHING**:seccomp-bpf
failure in syscall 0230" error.  

See https://github.com/electron/electron/issues/22291 for more details.