### PR TITLE
Object.fromEntries() should not force users to have a very recent browser

### DIFF
--- a/src/vector/index.js
+++ b/src/vector/index.js
@@ -27,7 +27,7 @@ require('highlight.js/styles/github.css');
 // These are things that can run before the skin loads - be careful not to reference the react-sdk though.
 import './rageshakesetup';
 import './modernizr';
-
+import './polyfills.js'
 // load service worker if available on this platform
 if ('serviceWorker' in navigator) {
     navigator.serviceWorker.register('sw.js');

--- a/src/vector/index.js
+++ b/src/vector/index.js
@@ -27,7 +27,7 @@ require('highlight.js/styles/github.css');
 // These are things that can run before the skin loads - be careful not to reference the react-sdk though.
 import './rageshakesetup';
 import './modernizr';
-import './polyfills.js'
+import './polyfills.js';
 // load service worker if available on this platform
 if ('serviceWorker' in navigator) {
     navigator.serviceWorker.register('sw.js');

--- a/src/vector/polyfills.js
+++ b/src/vector/polyfills.js
@@ -1,0 +1,9 @@
+if (typeof window.Object.fromEntries !== "function") {
+    // From https://github.com/feross/fromentries/blob/master/index.js
+    window.Object.fromEntries = function fromEntries(iterable) {
+        return [...iterable].reduce((obj, [key, val]) => {
+            obj[key] = val;
+            return obj;
+        }, {});
+    };
+}


### PR DESCRIPTION
Currently, Object.fromEntries() is required by the matrix-react-sdk  and used in one file (ReactionPicker.js). Not having this function triggers the compatibility page which warns the user that Riot won't function properly. 

However, Object.fromEntries() has been implemented in october 2018 in Firefox 63 and march 2019 in Chrome 73. This is pretty recent and some of our customers don't have these versions.

I thought it could be better to use a polyfill if this function doesn't exist to broader the compatibility of Riot. I'am not sure it should be included in Riot or matrix-react-sdk itself.

Please let me know what you think !

Maxime

