### PR TITLE
Revert "Remove useless app preloading from Jitsi widget wrapper"

### DIFF
--- a/src/vector/jitsi/index.ts
+++ b/src/vector/jitsi/index.ts
@@ -20,6 +20,7 @@ require("./index.scss");
 import * as qs from 'querystring';
 import { Capability, WidgetApi } from "matrix-react-sdk/src/widgets/WidgetApi";
 import SdkConfig from "matrix-react-sdk/src/SdkConfig";
+import { loadConfig, preparePlatform } from "../initial-load";
 
 // Dev note: we use raw JS without many dependencies to reduce bundle size.
 // We do not need all of React to render a Jitsi conference.
@@ -60,8 +61,12 @@ let widgetApi: WidgetApi;
             await widgetApi.setAlwaysOnScreen(false);
         });
 
+        // Bootstrap ourselves for loading the script and such
+        preparePlatform();
+        await loadConfig();
+
         // Populate the Jitsi params now
-        jitsiDomain = qsParam('conferenceDomain', false);
+        jitsiDomain = qsParam('conferenceDomain', true) || SdkConfig.get()['jitsi']['preferredDomain'];
         conferenceId = qsParam('conferenceId');
         displayName = qsParam('displayName', true);
         avatarUrl = qsParam('avatarUrl', true); // http not mxc


### PR DESCRIPTION
Reverts vector-im/riot-web#12836

Turns out we need the config information to be able to load the Jitsi widget info. Will find a better solution.