### PR TITLE
Don't immediately remove notifications from notification trays

### DIFF
--- a/src/vector/platform/WebPlatform.js
+++ b/src/vector/platform/WebPlatform.js
@@ -91,12 +91,6 @@ export default class WebPlatform extends VectorBasePlatform {
             global.focus();
             notification.close();
         };
-
-        // Chrome only dismisses notifications after 20s, which
-        // is waaaaay too long
-        global.setTimeout(function() {
-            notification.close();
-        }, 5 * 1000);
     }
 
     _getVersion(): Promise<string> {


### PR DESCRIPTION
Let the notifications go into browser/OS notification trays so users can click on them from there if they miss the initial notification. Modern Chrome uses OS notifications so the user is in control of the the notification with the OS. This also aligns with the Electron platform version.