### PR TITLE
Add a console warning that errors from Jitsi Meet are fine

### DIFF
--- a/src/vector/jitsi/index.ts
+++ b/src/vector/jitsi/index.ts
@@ -96,6 +96,11 @@ function joinConference() { // event handler bound in HTML
     // noinspection JSIgnoredPromiseFromCall
     widgetApi.setAlwaysOnScreen(true); // ignored promise because we don't care if it works
 
+    console.warn(
+        "[Jitsi Widget] The next few errors about failing to parse URL parameters are fine if " +
+        "they mention 'external_api' or 'jitsi' in the stack. They're just Jitsi Meet trying to parse " +
+        "our fragment values and not recognizing the options.",
+    );
     const meetApi = new JitsiMeetExternalAPI(jitsiDomain, {
         width: "100%",
         height: "100%",


### PR DESCRIPTION
See diff for info. This keeps tripping people up.

We use the fragment to avoid sending conference information to the web server where possible.