### PR TITLE
fix build:jitsi scripts crash caused by a missing folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "clean": "rimraf lib webapp electron_app/dist",
     "build": "yarn clean && yarn build:genfiles && yarn build:compile && yarn build:types && yarn build:bundle",
     "build-stats": "yarn clean && yarn build:genfiles && yarn build:compile && yarn build:types && yarn build:bundle-stats",
-    "build:jitsi": "curl -s https://jitsi.riot.im/libs/external_api.min.js > ./webapp/jitsi_external_api.min.js",
+    "build:jitsi": "scripts/build-jitsi.sh",
     "build:res": "node scripts/copy-res.js",
     "build:genfiles": "yarn reskindex && yarn build:res && yarn build:jitsi",
     "build:modernizr": "modernizr -c .modernizr.json -d src/vector/modernizr.js",

--- a/scripts/build-jitsi.sh
+++ b/scripts/build-jitsi.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if [[ ! -f "./webapp" ]]; then
+  mkdir "./webapp"
+fi
+
+curl -s https://jitsi.riot.im/libs/external_api.min.js > ./webapp/jitsi_external_api.min.js


### PR DESCRIPTION
On a freshly install of the development environment, the build:jitsi try to create a file in ./webapp with the cURL command. However, ./webapp folder doesn't exist and the build script crash. 

```
$ curl -s https://jitsi.riot.im/libs/external_api.min.js > ./webapp/jitsi_external_api.min.js
2020-04-10 13:41:05.148 [res] /bin/sh: ./webapp/jitsi_external_api.min.js: No such file or direc
error Command failed with exit code 1.
```

This patch makes sure the appropriate folder is created if it doesn't already exist