### PR TITLE
Add riot-desktop shortcuts for forward/back matching browsers&slack

### DIFF
--- a/electron_app/src/electron-main.js
+++ b/electron_app/src/electron-main.js
@@ -233,6 +233,16 @@ ipcMain.on('ipcCall', async function(ev, payload) {
         case 'getConfig':
             ret = vectorConfig;
             break;
+        case 'navigateBack':
+            if (mainWindow.webContents.canGoBack()) {
+                mainWindow.webContents.goBack();
+            }
+            break;
+        case 'navigateForward':
+            if (mainWindow.webContents.canGoForward()) {
+                mainWindow.webContents.goForward();
+            }
+            break;
 
         default:
             mainWindow.webContents.send('ipcReply', {

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -9,6 +9,7 @@
     "Unable to load config file: please refresh the page to try again.": "Unable to load config file: please refresh the page to try again.",
     "Unexpected error preparing the app. See console for details.": "Unexpected error preparing the app. See console for details.",
     "Open user settings": "Open user settings",
+    "Previous/next recently visited room or community": "Previous/next recently visited room or community",
     "Riot Desktop on %(platformName)s": "Riot Desktop on %(platformName)s",
     "Go to your browser to complete Sign In": "Go to your browser to complete Sign In",
     "Unknown device": "Unknown device",

--- a/src/vector/platform/ElectronPlatform.js
+++ b/src/vector/platform/ElectronPlatform.js
@@ -218,7 +218,7 @@ export default class ElectronPlatform extends VectorBasePlatform {
         this.startUpdateCheck = this.startUpdateCheck.bind(this);
         this.stopUpdateCheck = this.stopUpdateCheck.bind(this);
 
-        // register Mac specific shortcuts
+        // register OS-specific shortcuts
         if (isMac) {
             registerShortcut(Categories.NAVIGATION, {
                 keybinds: [{
@@ -226,6 +226,28 @@ export default class ElectronPlatform extends VectorBasePlatform {
                     key: Key.COMMA,
                 }],
                 description: _td("Open user settings"),
+            });
+
+            registerShortcut(Categories.NAVIGATION, {
+                keybinds: [{
+                    modifiers: [Modifiers.COMMAND],
+                    key: Key.SQUARE_BRACKET_LEFT,
+                }, {
+                    modifiers: [Modifiers.COMMAND],
+                    key: Key.SQUARE_BRACKET_RIGHT,
+                }],
+                description: _td("Previous/next recently visited room or community"),
+            });
+        } else {
+            registerShortcut(Categories.NAVIGATION, {
+                keybinds: [{
+                    modifiers: [Modifiers.ALT],
+                    key: Key.ARROW_LEFT,
+                }, {
+                    modifiers: [Modifiers.ALT],
+                    key: Key.ARROW_RIGHT,
+                }],
+                description: _td("Previous/next recently visited room or community"),
             });
         }
     }
@@ -433,5 +455,33 @@ export default class ElectronPlatform extends VectorBasePlatform {
             title: _t("Go to your browser to complete Sign In"),
             description: <Spinner />,
         });
+    }
+
+    _navigateForwardBack(back: boolean) {
+        this._ipcCall(back ? "navigateBack" : "navigateForward");
+    }
+
+    onKeyDown(ev: KeyboardEvent): boolean {
+        let handled = false;
+
+        switch (ev.key) {
+            case Key.SQUARE_BRACKET_LEFT:
+            case Key.SQUARE_BRACKET_RIGHT:
+                if (isMac && ev.metaKey && !ev.altKey && !ev.ctrlKey && !ev.shiftKey) {
+                    this._navigateForwardBack(ev.key === Key.SQUARE_BRACKET_LEFT);
+                    handled = true;
+                }
+                break;
+
+            case Key.ARROW_LEFT:
+            case Key.ARROW_RIGHT:
+                if (!isMac && ev.altKey && !ev.metaKey && !ev.ctrlKey && !ev.shiftKey) {
+                    this._navigateForwardBack(ev.key === Key.ARROW_LEFT);
+                    handled = true;
+                }
+                break;
+        }
+
+        return handled;
     }
 }


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/12920
Requires https://github.com/matrix-org/matrix-react-sdk/pull/4392
Requires https://github.com/vector-im/riot-desktop/pull/68

Matches browser default shortcuts for forward/back and also Slack

![image](https://user-images.githubusercontent.com/2403652/79051159-89292d00-7c26-11ea-9d8c-1bae82de90fe.png)


