### PR TITLE
docs: labs: add a pointer to config.md

### DIFF
--- a/docs/labs.md
+++ b/docs/labs.md
@@ -1,6 +1,7 @@
 # Labs features
 
-Some notes on the features you can enable by going to `Settings->Labs`. Not exhaustive, chat in
+If Labs is enabled in the [Riot config](config.md), you can enable some of these features by going
+to `Settings->Labs`. This list is non-exhaustive and subject to change, chat in
 [#riot-web:matrix.org](https://matrix.to/#/#riot-web:matrix.org) for more information.
 
 **Be warned! Labs features are not finalised, they may be fragile, they may change, they may be


### PR DESCRIPTION
The documentation mentions that Labs features can be manipulated by
opening the Settings menu and selecting Labs.  This feature is normally
disabled, so for most users this is not the case.

Add a link to the `config.md` file and a note that the Labs features
must be enabled in order to manipulate them.

Fixes https://github.com/vector-im/riot-web/issues/13148