### PR TITLE
Allow Riot Web to randomly pick welcome backgrounds

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -32,7 +32,7 @@ For a good example, see https://riot.im/develop/config.json.
    homeserver know what email template to use when talking to you.
 1. `branding`: Configures various branding and logo details, such as:
     1. `welcomeBackgroundUrl`: An image to use as a wallpaper outside the app
-       during authentication flows
+       during authentication flows. If an array is passed, an image is chosen randomly for each visit.
     1. `authHeaderLogoUrl`: An logo image that is shown in the header during
        authentication flows
     1. `authFooterLinks`: a list of links to show in the authentication page footer:

--- a/src/components/views/auth/VectorAuthPage.js
+++ b/src/components/views/auth/VectorAuthPage.js
@@ -29,7 +29,11 @@ export default class VectorAuthPage extends React.PureComponent {
         const brandingConfig = SdkConfig.get().branding;
         let backgroundUrl = "themes/riot/img/backgrounds/valley.jpg";
         if (brandingConfig && brandingConfig.welcomeBackgroundUrl) {
-            backgroundUrl = brandingConfig.welcomeBackgroundUrl;
+            if (Array.isArray(brandingConfig.welcomeBackgroundUrl)) {
+                backgroundUrl = brandingConfig.welcomeBackgroundUrl[ Math.floor(Math.random() * brandingConfig.welcomeBackgroundUrl.length)];
+            } else {
+                backgroundUrl = brandingConfig.welcomeBackgroundUrl;
+            }
         }
 
         const pageStyle = {

--- a/src/components/views/auth/VectorAuthPage.js
+++ b/src/components/views/auth/VectorAuthPage.js
@@ -30,7 +30,7 @@ export default class VectorAuthPage extends React.PureComponent {
         let backgroundUrl = "themes/riot/img/backgrounds/valley.jpg";
         if (brandingConfig && brandingConfig.welcomeBackgroundUrl) {
             if (Array.isArray(brandingConfig.welcomeBackgroundUrl)) {
-                backgroundUrl = brandingConfig.welcomeBackgroundUrl[ Math.floor(Math.random() * brandingConfig.welcomeBackgroundUrl.length)];
+                backgroundUrl = brandingConfig.welcomeBackgroundUrl[Math.floor(Math.random() * brandingConfig.welcomeBackgroundUrl.length)];
             } else {
                 backgroundUrl = brandingConfig.welcomeBackgroundUrl;
             }


### PR DESCRIPTION
This will allow the administrator of a Riot Web instance to set `welcomeBackgroundUrl` to an array. If they do, which one is displayed will be chosen at random on a per-visit basis. This allows them to add some variety to their branding.

**NOTE:** I was informed by [t3chguy that `Array.isArray()` is preferable to `instanceof Array`, so I went with that](https://iddqd.social/_matrix/media/r0/download/iddqd.social/uEtrywuxrjUbBfDAZxukSEaM). Any other critiques of my code are welcome.

Signed-off-by: Bob Arctor neetzsche@protonmail.com