### PR TITLE
Clarify that the .well-known method for Jitsi isn't available yet

### DIFF
--- a/docs/jitsi.md
+++ b/docs/jitsi.md
@@ -40,7 +40,8 @@ should start a new conference on your Jitsi server.
 domain will appear later in the URL as a configuration parameter.
 
 **Hint**: If you want everyone on your homeserver to use the same Jitsi server by
-default, set the following on your homeserver's `/.well-known/matrix/client` config:
+default, and you are using riot-web 1.6 or newer, set the following on your homeserver's 
+`/.well-known/matrix/client` config:
 ```json
 {
   "im.vector.riot.jitsi": {


### PR DESCRIPTION
We should remove this at release time, but if we forget it should be vaguely worded well enough.

People keep assuming it'll just work even though the feature hasn't launched yet. The original theory was that a release was around the corner, but it's since been pushed back several times.