### PR TITLE
Expand feature flag docs to cover additional release channels

### DIFF
--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -49,7 +49,9 @@ When starting work on a feature, we should create a matching feature flag:
 ```js
     SettingsStore.isFeatureEnabled("feature_cats")
 ```
-3. Add the feature to the [set of labs on develop](https://github.com/vector-im/riot-web/blob/develop/riot.im/develop/config.json):
+3. Add the feature to the set of labs on
+   [develop](https://github.com/vector-im/riot-web/blob/develop/riot.im/develop/config.json)
+   and [nightly](https://github.com/vector-im/riot-desktop/blob/master/riot.im/nightly/config.json):
 ```json
     "features": {
         "feature_cats": "labs"
@@ -58,14 +60,18 @@ When starting work on a feature, we should create a matching feature flag:
 4. Document the feature in the [labs documentation](https://github.com/vector-im/riot-web/blob/develop/docs/labs.md)
 
 With these steps completed, the feature is disabled by default, but can be
-enabled on develop by interested users for testing.
+enabled on develop and nightly by interested users for testing.
 
 Different features may have different deployment plans for when to enable where.
 The following lists a few common options.
 
-## Enabling by default on develop
+## Enabling by default on develop and nightly
 
-Set the feature to `enable` in the [develop config](https://github.com/vector-im/riot-web/blob/develop/riot.im/develop/config.json):
+Set the feature to `enable` in the
+[develop](https://github.com/vector-im/riot-web/blob/develop/riot.im/develop/config.json)
+and
+[nightly](https://github.com/vector-im/riot-desktop/blob/master/riot.im/nightly/config.json)
+configs:
 
 ```json
     "features": {
@@ -73,10 +79,21 @@ Set the feature to `enable` in the [develop config](https://github.com/vector-im
     },
 ```
 
-## Enabling by default on staging and app
+## Enabling by default on staging, app, and release
 
-Set the feature to `enable` in the [app
-config](https://github.com/vector-im/riot-web/blob/develop/riot.im/app/config.json).
+Set the feature to `enable` in the
+[staging / app](https://github.com/vector-im/riot-web/blob/develop/riot.im/app/config.json)
+and
+[release](https://github.com/vector-im/riot-desktop/blob/master/riot.im/release/config.json)
+configs.
+
+**Warning:** While this does mean the feature is enabled by default for
+https://riot.im and official Riot Desktop builds, it will not be enabled by
+default for self-hosted installs, custom desktop builds, etc. To cover those
+cases as well, the best options at the moment are converting to a regular
+setting defaulted on or to remove the flag. Simply enabling the existing flag by
+default in `Settings.js`
+[does not work currently](https://github.com/vector-im/riot-web/issues/10360).
 
 ## Feature deployed successfully
 
@@ -86,8 +103,11 @@ Once we're confident that a feature is working well, we should remove the flag:
 2. Remove all `isFeatureEnabled` lines that test for the feature's setting
 3. Remove the feature from the [labs documentation](https://github.com/vector-im/riot-web/blob/develop/docs/labs.md)
 4. Remove feature state from
-   [develop](https://github.com/vector-im/riot-web/blob/develop/riot.im/develop/config.json)
-   and [app](https://github.com/vector-im/riot-web/blob/develop/riot.im/app/config.json)
+   [develop](https://github.com/vector-im/riot-web/blob/develop/riot.im/develop/config.json),
+   [nightly](https://github.com/vector-im/riot-desktop/blob/master/riot.im/nightly/config.json),
+   [staging / app](https://github.com/vector-im/riot-web/blob/develop/riot.im/app/config.json),
+   and
+   [release](https://github.com/vector-im/riot-desktop/blob/master/riot.im/release/config.json)
    configs
 5. Celebrate! 🥳
 
@@ -107,6 +127,9 @@ regular setting:
    feature is always present but gated by a setting)
 3. Remove the feature from the [labs documentation](https://github.com/vector-im/riot-web/blob/develop/docs/labs.md)
 4. Remove feature state from
-   [develop](https://github.com/vector-im/riot-web/blob/develop/riot.im/develop/config.json)
-   and [app](https://github.com/vector-im/riot-web/blob/develop/riot.im/app/config.json)
+   [develop](https://github.com/vector-im/riot-web/blob/develop/riot.im/develop/config.json),
+   [nightly](https://github.com/vector-im/riot-desktop/blob/master/riot.im/nightly/config.json),
+   [staging / app](https://github.com/vector-im/riot-web/blob/develop/riot.im/app/config.json),
+   and
+   [release](https://github.com/vector-im/riot-desktop/blob/master/riot.im/release/config.json)
    configs

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -51,7 +51,7 @@ When starting work on a feature, we should create a matching feature flag:
 ```
 3. Add the feature to the set of labs on
    [develop](https://github.com/vector-im/riot-web/blob/develop/riot.im/develop/config.json)
-   and [nightly](https://github.com/vector-im/riot-desktop/blob/master/riot.im/nightly/config.json):
+   and [nightly](https://github.com/vector-im/riot-desktop/blob/develop/riot.im/nightly/config.json):
 ```json
     "features": {
         "feature_cats": "labs"
@@ -70,7 +70,7 @@ The following lists a few common options.
 Set the feature to `enable` in the
 [develop](https://github.com/vector-im/riot-web/blob/develop/riot.im/develop/config.json)
 and
-[nightly](https://github.com/vector-im/riot-desktop/blob/master/riot.im/nightly/config.json)
+[nightly](https://github.com/vector-im/riot-desktop/blob/develop/riot.im/nightly/config.json)
 configs:
 
 ```json
@@ -84,7 +84,7 @@ configs:
 Set the feature to `enable` in the
 [staging / app](https://github.com/vector-im/riot-web/blob/develop/riot.im/app/config.json)
 and
-[release](https://github.com/vector-im/riot-desktop/blob/master/riot.im/release/config.json)
+[release](https://github.com/vector-im/riot-desktop/blob/develop/riot.im/release/config.json)
 configs.
 
 **Warning:** While this does mean the feature is enabled by default for
@@ -104,10 +104,10 @@ Once we're confident that a feature is working well, we should remove the flag:
 3. Remove the feature from the [labs documentation](https://github.com/vector-im/riot-web/blob/develop/docs/labs.md)
 4. Remove feature state from
    [develop](https://github.com/vector-im/riot-web/blob/develop/riot.im/develop/config.json),
-   [nightly](https://github.com/vector-im/riot-desktop/blob/master/riot.im/nightly/config.json),
+   [nightly](https://github.com/vector-im/riot-desktop/blob/develop/riot.im/nightly/config.json),
    [staging / app](https://github.com/vector-im/riot-web/blob/develop/riot.im/app/config.json),
    and
-   [release](https://github.com/vector-im/riot-desktop/blob/master/riot.im/release/config.json)
+   [release](https://github.com/vector-im/riot-desktop/blob/develop/riot.im/release/config.json)
    configs
 5. Celebrate! 🥳
 
@@ -128,8 +128,8 @@ regular setting:
 3. Remove the feature from the [labs documentation](https://github.com/vector-im/riot-web/blob/develop/docs/labs.md)
 4. Remove feature state from
    [develop](https://github.com/vector-im/riot-web/blob/develop/riot.im/develop/config.json),
-   [nightly](https://github.com/vector-im/riot-desktop/blob/master/riot.im/nightly/config.json),
+   [nightly](https://github.com/vector-im/riot-desktop/blob/develop/riot.im/nightly/config.json),
    [staging / app](https://github.com/vector-im/riot-web/blob/develop/riot.im/app/config.json),
    and
-   [release](https://github.com/vector-im/riot-desktop/blob/master/riot.im/release/config.json)
+   [release](https://github.com/vector-im/riot-desktop/blob/develop/riot.im/release/config.json)
    configs


### PR DESCRIPTION
This adds further detail around the various additional release channels we have
for desktop. It also expands on the current state of enabling a feature by
default.