### PR TITLE
Add font scaling labs setting.

### DIFF
--- a/config.sample.json
+++ b/config.sample.json
@@ -26,6 +26,7 @@
     "defaultCountryCode": "GB",
     "showLabsSettings": false,
     "features": {
+        "feature_font_scaling": "labs",
         "feature_pinning": "labs",
         "feature_custom_status": "labs",
         "feature_custom_tags": "labs",

--- a/docs/labs.md
+++ b/docs/labs.md
@@ -7,6 +7,11 @@ to `Settings->Labs`. This list is non-exhaustive and subject to change, chat in
 **Be warned! Labs features are not finalised, they may be fragile, they may change, they may be
 dropped. Ask in the room if you are unclear about any details here.**
 
+## Font scaling (`feature_font_scaling`)
+
+Enables font scaling options for accessibility. To alter the scale check the
+appearance tab in settings.
+
 ## Message pinning (`feature_pinning`)
 
 Allows you to pin messages in the room. To pin a message, use the 3 dots to the right of the message

--- a/riot.im/develop/config.json
+++ b/riot.im/develop/config.json
@@ -13,6 +13,7 @@
     "hosting_signup_link": "https://modular.im/?utm_source=riot-web&utm_medium=web",
     "bug_report_endpoint_url": "https://riot.im/bugreports/submit",
     "features": {
+        "feature_font_scaling": "labs",
         "feature_pinning": "labs",
         "feature_custom_status": "labs",
         "feature_custom_tags": "labs",


### PR DESCRIPTION
Reverts vector-im/riot-web#13351
Replacement of https://github.com/vector-im/riot-web/pull/13199
**For https://github.com/matrix-org/matrix-react-sdk/pull/4424**

*This has already been approved, pending review of the react-sdk side*