### PR TITLE
Tweak default device name on macOS

### DIFF
--- a/src/vector/platform/WebPlatform.js
+++ b/src/vector/platform/WebPlatform.js
@@ -3,6 +3,7 @@
 /*
 Copyright 2016 Aviral Dasgupta
 Copyright 2016 OpenMarket Ltd
+Copyright 2017-2020 New Vector Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/vector/platform/WebPlatform.js
+++ b/src/vector/platform/WebPlatform.js
@@ -186,7 +186,9 @@ export default class WebPlatform extends VectorBasePlatform {
 
         const ua = new UAParser();
         const browserName = ua.getBrowser().name || "unknown browser";
-        const osName = ua.getOS().name || "unknown os";
+        let osName = ua.getOS().name || "unknown OS";
+        // Stylise the value from the parser to match Apple's current branding.
+        if (osName === "Mac OS") osName = "macOS";
         return _t('%(appName)s via %(browserName)s on %(osName)s', {appName: appName, browserName: browserName, osName: osName});
     }
 


### PR DESCRIPTION
This tweak's the OS name in the default device name for macOS devices to match
Apple's current branding.

<img width="517" alt="2020-04-30 at 15 58" src="https://user-images.githubusercontent.com/279572/80725946-a94c5d80-8afb-11ea-8e22-99a8d8473430.png">

Fixes https://github.com/vector-im/riot-web/issues/13459