### PR TITLE
Specify a size for URL previews

### DIFF
--- a/src/vector/index.html
+++ b/src/vector/index.html
@@ -22,6 +22,8 @@
     <meta name="msapplication-config" content="<%= require('../../res/vector-icons/browserconfig.xml') %>">
     <meta name="theme-color" content="#ffffff">
     <meta property="og:image" content="<%= htmlWebpackPlugin.options.vars.og_image_url %>" />
+    <meta property="og:image:width" content="64" />
+    <meta property="og:image:height" content="64" />
     <meta http-equiv="Content-Security-Policy" content="
         default-src 'none';
         style-src 'self' 'unsafe-inline';


### PR DESCRIPTION
This is kinda hard to test on the fly, nobody wants to URL-preview localhost

Fixes: https://github.com/vector-im/riot-web/issues/12014

Best only close the ticket once confirmed in prod