### PR TITLE
Added Anchor Link to the development of matrix sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ Development
 ===========
 
 Before attempting to develop on Riot you **must** read the [developer guide
-for `matrix-react-sdk`](https://github.com/matrix-org/matrix-react-sdk), which
+for `matrix-react-sdk`](https://github.com/matrix-org/matrix-react-sdk#developer-guide), which
 also defines the design, architecture and style for Riot too.
 
 Before starting work on a feature, it's best to ensure your plan aligns well


### PR DESCRIPTION
The link before just sent you to the matrix sdk repository, now it sends you to the development section.