### PR TITLE
Add notranslate class to matrixchat to prevent translation by Google Translate

### DIFF
--- a/src/vector/index.html
+++ b/src/vector/index.html
@@ -51,7 +51,7 @@
   </head>
   <body style="height: 100%; margin: 0;" data-vector-indexeddb-worker-script="<%= htmlWebpackPlugin.files.chunks['indexeddb-worker'].entry %>">
     <noscript>Sorry, Riot requires JavaScript to be enabled.</noscript> <!-- TODO: Translate this? -->
-    <section id="matrixchat" style="height: 100%; overflow: auto;"></section>
+    <section id="matrixchat" style="height: 100%; overflow: auto;" class="notranslate"></section>
     <script src="<%= htmlWebpackPlugin.files.chunks['bundle'].entry %>"></script>
 
     <!-- Legacy supporting Prefetch images -->


### PR DESCRIPTION
Google Translate manipulates the DOM which is fundamentally incomaptible with
React and causes exceptions to be thrown when React tries to manipulate the DOM
based on its VDOM and the DOM methods throw exceptions because the DOM structure
is not what React thinks it is.

Riot has an i18n system, although it doesn't cover all strings and all languages.

Fixes https://github.com/vector-im/riot-web/issues/13557
Alternative to: https://github.com/vector-im/riot-web/pull/13658