### PR TITLE
Fix postcss order to allow mixin variables to work

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -216,10 +216,10 @@ module.exports = (env, argv) => {
                                     // Note that we use slightly different plugins for SCSS.
 
                                     require('postcss-import')(),
+                                    require("postcss-mixins")(),
                                     require("postcss-simple-vars")(),
                                     require("postcss-extend")(),
                                     require("postcss-nested")(),
-                                    require("postcss-mixins")(),
                                     require("postcss-easings")(),
                                     require("postcss-strip-inline-comments")(),
                                     require("postcss-hexrgba")(),


### PR DESCRIPTION
> Note, that you must set this plugin before postcss-simple-vars and postcss-nested.

https://github.com/postcss/postcss-mixins