### PR TITLE
Allow deferring of Update Toast until the next morning

### DIFF
--- a/src/vector/platform/ElectronPlatform.tsx
+++ b/src/vector/platform/ElectronPlatform.tsx
@@ -275,8 +275,10 @@ export default class ElectronPlatform extends VectorBasePlatform {
         return this._ipcCall('getConfig');
     }
 
-    async onUpdateDownloaded(ev, updateInfo) {
-        showUpdateToast(await this.getAppVersion(), updateInfo, updateInfo.releaseNotes);
+    async onUpdateDownloaded(ev, {releaseNotes, releaseName}) {
+        if (this.shouldShowUpdate(releaseName)) {
+            showUpdateToast(await this.getAppVersion(), releaseName, releaseNotes);
+        }
     }
 
     getHumanReadableName(): string {

--- a/src/vector/platform/VectorBasePlatform.ts
+++ b/src/vector/platform/VectorBasePlatform.ts
@@ -94,14 +94,6 @@ export default abstract class VectorBasePlatform extends BasePlatform {
     }
 
     /**
-     * Update the currently running app to the latest available
-     * version and replace this instance of the app with the
-     * new version.
-     */
-    installUpdate() {
-    }
-
-    /**
      * Get a sensible default display name for the
      * device Vector is running on
      */

--- a/src/vector/platform/WebPlatform.ts
+++ b/src/vector/platform/WebPlatform.ts
@@ -140,7 +140,9 @@ export default class WebPlatform extends VectorBasePlatform {
             if (this.runningVersion === null) {
                 this.runningVersion = ver;
             } else if (this.runningVersion !== ver) {
-                showUpdateToast(this.runningVersion, ver);
+                if (this.shouldShowUpdate(ver)) {
+                    showUpdateToast(this.runningVersion, ver);
+                }
                 return { status: UpdateCheckStatus.Ready };
             } else {
                 hideUpdateToast();


### PR DESCRIPTION
Fixes https://github.com/vector-im/riot-web/issues/11042
Staged atop https://github.com/vector-im/riot-web/pull/13862
Requires https://github.com/matrix-org/matrix-react-sdk/pull/4669

![image](https://user-images.githubusercontent.com/2403652/83295695-4c6dc100-a1e7-11ea-9f97-1c766a7c2e03.png)

Later will defer it until the first of the following:
+ tomorrow morning (8am)
+ the user clicks `Check for update` in settings
+ an even newer update comes out

