### PR TITLE
Fix login loop where the sso flow returns to `#/login`

### DIFF
--- a/src/vector/platform/ElectronPlatform.tsx
+++ b/src/vector/platform/ElectronPlatform.tsx
@@ -457,8 +457,8 @@ export default class ElectronPlatform extends VectorBasePlatform {
         });
     }
 
-    getSSOCallbackUrl(hsUrl: string, isUrl: string, fragmentAfterLogin: string): URL {
-        const url = super.getSSOCallbackUrl(hsUrl, isUrl, fragmentAfterLogin);
+    getSSOCallbackUrl(fragmentAfterLogin: string): URL {
+        const url = super.getSSOCallbackUrl(fragmentAfterLogin);
         url.protocol = "riot";
         url.searchParams.set("riot-desktop-ssoid", this.ssoID);
         return url;

--- a/src/vector/platform/VectorBasePlatform.ts
+++ b/src/vector/platform/VectorBasePlatform.ts
@@ -37,12 +37,6 @@ export const updateCheckStatusEnum = {
 export default abstract class VectorBasePlatform extends BasePlatform {
     protected _favicon: Favicon;
 
-    constructor() {
-        super();
-
-        this.startUpdateCheck = this.startUpdateCheck.bind(this);
-    }
-
     async getConfig(): Promise<{}> {
         return getVectorConfig();
     }


### PR DESCRIPTION
due to fragmentAfterLogin going back to `#/login` and https://github.com/vector-im/riot-web/issues/11643
Requires https://github.com/matrix-org/matrix-react-sdk/pull/4685