### PR TITLE
Jitsi: Simple way to join a jitsi room with a manual jwt token

### DIFF
--- a/src/vector/jitsi/index.html
+++ b/src/vector/jitsi/index.html
@@ -12,6 +12,11 @@
             <!-- TODO: i18n -->
             <h2>Jitsi Video Conference</h2>
             <button type="button" id="joinButton">Join Conference</button>
+            <details id="jwtTokenDetails">
+                <summary>JWT token</summary>
+                <p>To start and moderate jitsi room <input type="text" id="jitsiRoom" readonly=""></p>
+                <textarea id="jwtToken"></textarea>
+            </details>
         </div>
     </div>
 </div>

--- a/src/vector/jitsi/index.scss
+++ b/src/vector/jitsi/index.scss
@@ -73,3 +73,30 @@ body, html {
     background-color: #03b381;
     border: 0;
 }
+
+#jwtTokenDetails {
+    width: 50%;
+    margin: 15px auto;
+
+    summary {
+        color: #03b381;
+        font-size: 0.6rem;
+	cursor: pointer;
+    }
+
+    p {
+      font-size:0.8rem;
+    }
+
+    #jitsiRoom, #jwtToken{
+	border:1px solid #03b381;
+	background-color: #181b21;
+	color: #edf3ff;
+	border-radius:4px;
+	font-size:0.8rem;
+    }
+    #jwtToken {
+	width:100%;
+	height:80px;
+    }
+}

--- a/src/vector/jitsi/index.ts
+++ b/src/vector/jitsi/index.ts
@@ -133,7 +133,7 @@ function joinConference(widgetId) { // event handler bound in HTML
             MAIN_TOOLBAR_BUTTONS: [],
             VIDEO_LAYOUT_FIT: "height",
         },
-	jwt: document.querySelector('#jwtToken'),
+	jwt: document.querySelector('#jwtToken')["value"] || undefined,
     });
 
     if (displayName) meetApi.executeCommand("displayName", displayName);

--- a/src/vector/jitsi/index.ts
+++ b/src/vector/jitsi/index.ts
@@ -84,7 +84,7 @@ let widgetApi: WidgetApi;
 	  if (current_jwt[roomId]){
 	    document.getElementById("jwtToken")["value"] = current_jwt[roomId][widgetId] || "";
 	    if (current_jwt[roomId][widgetId]){
-	      document.getElementById("jwtTokenDetails").setAttribute("open", true);
+	      document.getElementById("jwtTokenDetails").setAttribute("open", "true");
 	    } else {
 	      document.getElementById("jwtTokenDetails").removeAttribute("open")
 	    }


### PR DESCRIPTION
With a self-hosted jitsi server [JWT tokens](https://github.com/jitsi/lib-jitsi-meet/blob/master/doc/tokens.md) are the way to give access automatically and at same time protect against unauthorized guest room creation.
I found it useful to put in riot some way to enter the jwt token. By now obtaining the token is manually but I think that with some little work it can be done automatically. (notes below)

Mockup proposal about provide tokens automatically by the HS:

Maybe the better way should be to keep the secret (or the private key) to be able to generate jwt tokens in some way in matrix homeserver and then find a way to request jwt tokens to server (maybe widget api...), and answer with a token depending on the user power level.
Then at local widget level fill the jwt token field automatically, but only for the user who request the token or the widget and has a concrete power level. 
Adding a jwt token url parameter for a jitsi that has not enabled it is harmless. So it can be always filled.
The jwt token field in riot widget (done in src/vector/jitsi/index.ts) will be the place to enter the token, if there's a good answer from server then fill it, if not leave blank. 

Also, by now a simple bot could be used by now to request the jwt token. 

But as I said by now the homeserver part is not there, so we only can create room jwt tokens manually by the one who has the secret or the allowed private key. 

It's my first contribution in riot so i don't know if the PR is fully usable, i think so, but maybe the use of localstorage from the widget is not recommended, or maybe it's better to use indexeddb... Excuse me if I omit something.