### PR TITLE
ElectronPlatform: Add support to set and get the index user version.

### DIFF
--- a/src/vector/platform/ElectronPlatform.tsx
+++ b/src/vector/platform/ElectronPlatform.tsx
@@ -193,6 +193,14 @@ class SeshatIndexManager extends BaseEventIndexManager {
         return this._ipcCall('getStats');
     }
 
+    async getUserVersion(): Promise<number> {
+        return this._ipcCall('getUserVersion');
+    }
+
+    async setUserVersion(version: number): Promise<void> {
+        return this._ipcCall('setUserVersion', version);
+    }
+
     async deleteEventIndex(): Promise<void> {
         return this._ipcCall('deleteEventIndex');
     }


### PR DESCRIPTION
The react-sdk side of this can be found at https://github.com/matrix-org/matrix-react-sdk/pull/4788, while the Riot-desktop side is at https://github.com/vector-im/riot-desktop/pull/102.

Requires a Seshat release with https://github.com/matrix-org/seshat/pull/67.