### PR TITLE
Remove font scaling from labs

### DIFF
--- a/config.sample.json
+++ b/config.sample.json
@@ -27,7 +27,6 @@
     "showLabsSettings": false,
     "features": {
         "feature_new_spinner": "labs",
-        "feature_font_scaling": "labs",
         "feature_pinning": "labs",
         "feature_custom_status": "labs",
         "feature_custom_tags": "labs",

--- a/docs/labs.md
+++ b/docs/labs.md
@@ -11,11 +11,6 @@ dropped. Ask in the room if you are unclear about any details here.**
 
 Replaces the old spinner image with a new, svg-based one featuring a sleeker design.
 
-## Font scaling (`feature_font_scaling`)
-
-Enables font scaling options for accessibility. To alter the scale check the
-appearance tab in settings.
-
 ## Message pinning (`feature_pinning`)
 
 Allows you to pin messages in the room. To pin a message, use the 3 dots to the right of the message

--- a/riot.im/develop/config.json
+++ b/riot.im/develop/config.json
@@ -14,7 +14,6 @@
     "bug_report_endpoint_url": "https://riot.im/bugreports/submit",
     "features": {
         "feature_new_spinner": "labs",
-        "feature_font_scaling": "labs",
         "feature_pinning": "labs",
         "feature_custom_status": "labs",
         "feature_custom_tags": "labs",


### PR DESCRIPTION
Just a quick fire pr to remove font-scaling from labs. No review requested yet as font-scaling needs to be reviewed after the new room list lands.

requires: https://github.com/matrix-org/matrix-react-sdk/pull/4899
requires: https://github.com/vector-im/riot-desktop/pull/112