### PR TITLE
Fix arm docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,8 @@ ARG REACT_SDK_BRANCH="master"
 ARG JS_SDK_REPO="https://github.com/matrix-org/matrix-js-sdk.git"
 ARG JS_SDK_BRANCH="master"
 
-RUN apt-get update && apt-get install -y git dos2unix
+RUN apt-get update && apt-get install -y git dos2unix \
+  build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
 
 WORKDIR /src
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,8 @@ ARG JS_SDK_REPO="https://github.com/matrix-org/matrix-js-sdk.git"
 ARG JS_SDK_BRANCH="master"
 
 RUN apt-get update && apt-get install -y git dos2unix \
+# These packages are required for building Canvas on architectures like Arm
+# See https://www.npmjs.com/package/canvas#compiling
   build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
 
 WORKDIR /src

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Builder
-FROM node:10 as builder
+FROM node:12 as builder
 
 # Support custom branches of the react-sdk and js-sdk. This also helps us build
 # images of riot-web develop.


### PR DESCRIPTION
History is at: https://matrix.to/#/!YTvKGNlinIzlkMTVRl:matrix.org/$4Se7Bpo2lakGZLGxnsXA8WQlCHtMLrJRs8qiNshzBKA?via=matrix.org&via=privacytools.io&via=mozilla.org
(Transcript below)

In short, trying to build an Arm binary of the Docker image for riot-web on either a Raspberry Pi 3 or a MacBook via Docker buildx, there are no pre-built binaries available for `canvas`, and building it causes `webpack` to run out of memory. These two commits seem to rectify these issues.

Chat transcript
---

Matt Cengia (he/him/his)
> Hey folks, I'm trying to get Riot installed, via Docker, onto a Raspberry Pi 3. When I try to build the Docker image, either on my RPi, or on an emulated Arm container on my Mac via docker buildx, I get an error about 'canvas'. I'm building v1.6.7, and when I try to build the same image as an amd64 image, it works fine. Any ideas what's going on? Here's a gist of the error I get (I tried manually stepping through the Docker container build to debug it):
> https://gist.github.com/cac6efa0e9730ae84397a6fad9a9609d

Michael (t3chguy)
> Matt Cengia (he/him/his): https://github.com/vector-im/riot-web/issues/14400#issuecomment-657106643

Matt Cengia (he/him/his)
> Ah, right. Thanks, Michael (t3chguy) . Is this something for which I could propose a patch to the Dockerfile?

Michael (t3chguy)
> Sure